### PR TITLE
chore: Add ASH_VERSION env var. Add ash version to CI matrix.

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -11,14 +11,17 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    name: OTP ${{matrix.otp}} / Elixir ${{matrix.elixir}}
+    name: OTP ${{matrix.otp}} / Elixir ${{matrix.elixir}} / Ash ${{matrix.ash}}
     strategy:
+      fail-fast: false
       matrix:
-        otp: ["23"]
+        otp: ["23", "22"]
         elixir: ["1.10.0"]
+        ash: ["master", "1.9", "1.8"]
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       ASH_CI: true
+      ASH_VERSION: ${{matrix.ash}}
     steps:
       - run: sudo apt-get install --yes erlang-dev
       - uses: actions/checkout@v2
@@ -63,5 +66,3 @@ jobs:
           consumer-secret: ${{ secrets.TWITTER_CONSUMER_API_SECRET }}
           access-token: ${{ secrets.TWITTER_ACCESS_TOKEN }}
           access-token-secret: ${{ secrets.TWITTER_ACCESS_TOKEN_SECRET }}
-
-

--- a/mix.exs
+++ b/mix.exs
@@ -61,7 +61,7 @@ defmodule AshPostgres.MixProject do
     [
       {:ecto_sql, "~> 3.4"},
       {:postgrex, ">= 0.0.0"},
-      {:ash, "~> 1.9"},
+      {:ash, ash_version("~> 1.9")},
       {:git_ops, "~> 2.0.1", only: :dev},
       {:ex_doc, "~> 0.22", only: :dev, runtime: false},
       {:ex_check, "~> 0.11.0", only: :dev},
@@ -70,6 +70,15 @@ defmodule AshPostgres.MixProject do
       {:sobelow, ">= 0.0.0", only: :dev, runtime: false},
       {:excoveralls, "~> 0.13.0", only: [:dev, :test]}
     ]
+  end
+
+  defp ash_version(default_version) do
+    case System.get_env("ASH_VERSION") do
+      nil -> default_version
+      "local" -> [path: "../ash"]
+      "master" -> [git: "https://github.com/ash-project/ash.git"]
+      version -> "~> #{version}"
+    end
   end
 
   defp aliases do


### PR DESCRIPTION
`ASH_VERSION` env var now supported. Same value has to be present (or not specified) for all mix actions including `deps.get`, `compile`, and running the application. Options:

`ASH_VERSION=local` -> `path: "../ash"`
`ASH_VERSION=master` -> `git: "https://github.com/ash-project/ash.git"`
`ASH_VERSION=1.8` -> `"~> 1.8"`
(nothing) -> default specified in deps in `mix.exs`. This should be updated in this project as new versions of ash are released.

Addresses:  https://github.com/ash-project/ash/issues/50