### PR TITLE
Do not overwrite migrations, create new using pattern timestamp.table.json

### DIFF
--- a/lib/migration_generator/migration_generator.ex
+++ b/lib/migration_generator/migration_generator.ex
@@ -333,12 +333,13 @@ defmodule AshPostgres.MigrationGenerator do
           snapshot_folder
           |> Path.join(snapshot.table <> ".version.json")
 
-        version_binary = snapshot_to_binary(%{
-          latest_version: snapshot_file
-        })
+        version_binary =
+          snapshot_to_binary(%{
+            latest_version: snapshot_file
+          })
+
         File.mkdir_p(Path.dirname(version_file))
         File.write!(version_file, version_binary, [])
-
       end)
     end
 
@@ -955,6 +956,7 @@ defmodule AshPostgres.MigrationGenerator do
 
     # get name of latest version file.
     version_file = Path.join(folder, snapshot.table <> ".version.json")
+
     file =
       if File.exists?(version_file) do
         file_content =

--- a/test/migration_generator_test.exs
+++ b/test/migration_generator_test.exs
@@ -90,6 +90,7 @@ defmodule AshPostgres.MigrationGeneratorTest do
 
     test "the snapshots contain valid json" do
       assert File.exists?(Path.join(["test_snapshots_path", "test_repo", "posts.version.json"]))
+
       assert File.read!(Path.wildcard("test_snapshots_path/test_repo/*_posts.json"))
              |> Jason.decode!(keys: :atoms!)
 

--- a/test/migration_generator_test.exs
+++ b/test/migration_generator_test.exs
@@ -79,16 +79,25 @@ defmodule AshPostgres.MigrationGeneratorTest do
     end
 
     test "it creates a snapshot for each resource" do
-      assert File.exists?(Path.join(["test_snapshots_path", "test_repo", "posts.json"]))
+      assert File.exists?(Path.wildcard("test_snapshots_path/test_repo/*_posts.json"))
+      assert File.exists?(Path.join(["test_snapshots_path", "test_repo", "posts.version.json"]))
     end
 
     test "the snapshots can be loaded" do
-      assert File.exists?(Path.join(["test_snapshots_path", "test_repo", "posts.json"]))
+      assert File.exists?(Path.wildcard("test_snapshots_path/test_repo/*_posts.json"))
+      assert File.exists?(Path.join(["test_snapshots_path", "test_repo", "posts.version.json"]))
     end
 
     test "the snapshots contain valid json" do
-      assert File.read!(Path.join(["test_snapshots_path", "test_repo", "posts.json"]))
+      assert File.exists?(Path.join(["test_snapshots_path", "test_repo", "posts.version.json"]))
+      assert File.read!(Path.wildcard("test_snapshots_path/test_repo/*_posts.json"))
              |> Jason.decode!(keys: :atoms!)
+
+      version_file_content =
+        File.read!(Path.join(["test_snapshots_path", "test_repo", "posts.version.json"]))
+        |> Jason.decode!(keys: :atoms!)
+
+      assert Map.get(version_file_content, :latest_version, nil) != nil
     end
 
     test "the migration creates the table" do


### PR DESCRIPTION
Create migration file using pattern timestamp.table.json and track latest version using file table_name.version.json

### Contributor checklist

- [x] Bug fixes include regression tests
- [x] Features include unit/acceptance tests
