### PR TITLE
Make integer serial if generated

### DIFF
--- a/lib/migration_generator/migration_generator.ex
+++ b/lib/migration_generator/migration_generator.ex
@@ -1120,7 +1120,7 @@ defmodule AshPostgres.MigrationGenerator do
     resource
     |> Ash.Resource.attributes()
     |> Enum.sort_by(& &1.name)
-    |> Enum.map(&Map.take(&1, [:name, :type, :default, :allow_nil?, :primary_key?]))
+    |> Enum.map(&Map.take(&1, [:name, :type, :default, :allow_nil?, :generated?, :primary_key?]))
     |> Enum.map(fn attribute ->
       default = default(attribute, repo)
 

--- a/lib/migration_generator/operation.ex
+++ b/lib/migration_generator/operation.ex
@@ -90,6 +90,12 @@ defmodule AshPostgres.MigrationGenerator.Operation do
       }"
     end
 
+    def up(%{attribute: %{type: :integer, default: "nil", generated?: true} = attribute}) do
+      "add #{inspect(attribute.name)}, :serial, null: #{attribute.allow_nil?}, primary_key: #{
+        attribute.primary_key?
+      }"
+    end
+
     def up(%{attribute: attribute}) do
       "add #{inspect(attribute.name)}, #{inspect(attribute.type)}, null: #{attribute.allow_nil?}, default: #{
         attribute.default

--- a/test/migration_generator_test.exs
+++ b/test/migration_generator_test.exs
@@ -359,7 +359,7 @@ defmodule AshPostgres.MigrationGeneratorTest do
 
       defposts do
         attributes do
-          attribute(:id, :integer, generated?: true, primary_key?: true)
+          attribute(:id, :integer, generated?: true, allow_nil?: false, primary_key?: true)
           attribute(:views, :integer, default: nil)
         end
       end
@@ -382,7 +382,7 @@ defmodule AshPostgres.MigrationGeneratorTest do
       assert [file] = Path.wildcard("test_migration_path/**/*_migrate_resources*.exs")
 
       assert File.read!(file) =~
-               ~S[add :id, :serial, null: true, primary_key: true]
+               ~S[add :id, :serial, null: false, primary_key: true]
 
       assert File.read!(file) =~
                ~S[add :views, :integer, null: true, default: nil, primary_key: false]


### PR DESCRIPTION
### Contributor checklist

- [ ] Bug fixes include regression tests
- [x] Features include unit/acceptance tests

Before merging this, I'd like to change the default behaviour of integer_primary_key over in ash-project/ash. It currently defaults `allow_nil?` to true, which is incompatible with :serial

fixes #32