### PR TITLE
Use ecto_sql formatter settings

### DIFF
--- a/lib/migration_generator/migration_generator.ex
+++ b/lib/migration_generator/migration_generator.ex
@@ -509,7 +509,7 @@ defmodule AshPostgres.MigrationGenerator do
 
   defp format(string, opts) do
     if opts.format do
-      Code.format_string!(string)
+      Code.format_string!(string, locals_without_parens: ecto_sql_locals_without_parens())
     else
       string
     end
@@ -524,6 +524,17 @@ defmodule AshPostgres.MigrationGenerator do
       """)
 
       reraise exception, __STACKTRACE__
+  end
+
+  defp ecto_sql_locals_without_parens do
+    path = File.cwd!() |> Path.join("deps/ecto_sql/.formatter.exs")
+
+    if File.exists?(path) do
+      {opts, _} = Code.eval_file(path)
+      Keyword.get(opts, :locals_without_parens, [])
+    else
+      []
+    end
   end
 
   defp streamline(ops, acc \\ [])


### PR DESCRIPTION
Use `ecto_sql`'s formatter config when generating migrations. 

I'm using `File.cwd!/1` here, as suggested by José:
> if the project is being compiled with Mix, "File.cwd!" will always point to the root directory because Mix always runs from root
(https://groups.google.com/g/elixir-lang-talk/c/Ls0eJDdMMW8/m/VLWWAKWPAQAJ)