### PR TITLE
Fix incorrect joins

### DIFF
--- a/lib/migration_generator/operation.ex
+++ b/lib/migration_generator/operation.ex
@@ -3,7 +3,13 @@ defmodule AshPostgres.MigrationGenerator.Operation do
 
   defmodule Helper do
     @moduledoc false
-    def join(list), do: list |> List.flatten() |> Enum.reject(&is_nil/1) |> Enum.join(", ")
+    def join(list),
+      do:
+        list
+        |> List.flatten()
+        |> Enum.reject(&is_nil/1)
+        |> Enum.join(", ")
+        |> String.replace(", )", ")")
 
     def maybe_add_default("nil"), do: nil
     def maybe_add_default(value), do: "default: #{value}"


### PR DESCRIPTION
Joining this
```elixir
"references(#{inspect(table)}",
[
  "type: #{inspect(attribute.type)}",
  "column: #{inspect(destination_field)}",
  "with: [#{source_attribute}: :#{destination_attribute}]"
],
")",
```
currently generates a function call ending with `, )`.