### PR TITLE
fix: Made AshPostgres.Repo.init/2 overridable

### DIFF
--- a/lib/repo.ex
+++ b/lib/repo.ex
@@ -57,7 +57,7 @@ defmodule AshPostgres.Repo do
         {:ok, new_config}
       end
 
-      defoverridable installed_extensions: 0, all_tenants: 0, tenant_migrations_path: 0
+      defoverridable init: 2, installed_extensions: 0, all_tenants: 0, tenant_migrations_path: 0
     end
   end
 end


### PR DESCRIPTION
Made AshPostgres.Repo.init/2 overridable so that one can do custom things before calling super inside init/2.

### Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests
