### PR TITLE
improvement: primary autoincrement key as bigserial

### DIFF
--- a/lib/migration_generator/operation.ex
+++ b/lib/migration_generator/operation.ex
@@ -178,7 +178,7 @@ defmodule AshPostgres.MigrationGenerator.Operation do
     def up(%{attribute: %{type: :integer, default: "nil", generated?: true} = attribute}) do
       [
         "add #{inspect(attribute.name)}",
-        ":serial",
+        ":bigserial",
         maybe_add_null(attribute.allow_nil?),
         maybe_add_primary_key(attribute.primary_key?)
       ]

--- a/test/migration_generator_test.exs
+++ b/test/migration_generator_test.exs
@@ -411,11 +411,11 @@ defmodule AshPostgres.MigrationGeneratorTest do
       :ok
     end
 
-    test "when an integer is generated and default nil, it is a serial" do
+    test "when an integer is generated and default nil, it is a bigserial" do
       assert [file] = Path.wildcard("test_migration_path/**/*_migrate_resources*.exs")
 
       assert File.read!(file) =~
-               ~S[add :id, :serial, null: false, primary_key: true]
+               ~S[add :id, :bigserial, null: false, primary_key: true]
 
       assert File.read!(file) =~
                ~S[add :views, :integer]


### PR DESCRIPTION
### Contributor checklist

- [ ] Bug fixes include regression tests
- [x] Features include unit/acceptance tests

Sets the autoincrement keys as `:bigserial`, this is common standard for Ecto as well