### PR TITLE
Relationships references should follow bigint ids schema as well 

### DIFF
--- a/lib/migration_generator/operation.ex
+++ b/lib/migration_generator/operation.ex
@@ -39,6 +39,9 @@ defmodule AshPostgres.MigrationGenerator.Operation do
     end
 
     def on_update(_), do: nil
+
+    def integer_to_bigint(:integer), do: ":bigint"
+    def integer_to_bigint(type), do: inspect(type)
   end
 
   defmodule CreateTable do
@@ -68,7 +71,7 @@ defmodule AshPostgres.MigrationGenerator.Operation do
         "add #{inspect(attribute.name)}",
         "references(:#{table}",
         [
-          "type: #{inspect(attribute.type)}",
+          "type: #{integer_to_bigint(attribute.type)}",
           "column: #{inspect(destination_field)}",
           "with: [#{source_attribute}: :#{destination_attribute}]",
           "name: #{inspect(reference.name)}",
@@ -98,7 +101,7 @@ defmodule AshPostgres.MigrationGenerator.Operation do
         "add #{inspect(attribute.name)}",
         "references(:#{table}",
         [
-          "type: #{inspect(attribute.type)}",
+          "type: #{integer_to_bigint(attribute.type)}",
           "column: #{inspect(destination_field)}",
           "prefix: \"public\"",
           "name: #{inspect(reference.name)}",
@@ -140,7 +143,7 @@ defmodule AshPostgres.MigrationGenerator.Operation do
         "add #{inspect(attribute.name)}",
         "references(:#{table}",
         [
-          "type: #{inspect(attribute.type)}",
+          "type: #{integer_to_bigint(attribute.type)}",
           "column: #{inspect(destination_field)}",
           "name: #{inspect(reference.name)}",
           on_delete(reference),
@@ -162,7 +165,7 @@ defmodule AshPostgres.MigrationGenerator.Operation do
         "add #{inspect(attribute.name)}",
         "references(:#{table}",
         [
-          "type: #{inspect(attribute.type)}",
+          "type: #{integer_to_bigint(attribute.type)}",
           "column: #{inspect(destination_field)}",
           "name: #{inspect(reference.name)}",
           on_delete(reference),
@@ -269,7 +272,9 @@ defmodule AshPostgres.MigrationGenerator.Operation do
              } = reference
          }) do
       join([
-        "references(:#{table}, type: #{inspect(type)}, column: #{inspect(destination_field)}",
+        "references(:#{table}, type: #{integer_to_bigint(type)}, column: #{
+          inspect(destination_field)
+        }",
         "name: #{inspect(reference.name)}",
         on_delete(reference),
         on_update(reference),
@@ -287,9 +292,9 @@ defmodule AshPostgres.MigrationGenerator.Operation do
              } = reference
          }) do
       join([
-        "references(:#{table}, type: #{inspect(type)}, column: #{inspect(destination_field)}, with: [#{
-          source_attribute
-        }: :#{destination_attribute}]",
+        "references(:#{table}, type: #{integer_to_bigint(type)}, column: #{
+          inspect(destination_field)
+        }, with: [#{source_attribute}: :#{destination_attribute}]",
         "name: #{inspect(reference.name)}",
         on_delete(reference),
         on_update(reference),
@@ -309,7 +314,9 @@ defmodule AshPostgres.MigrationGenerator.Operation do
            }
          ) do
       join([
-        "references(:#{table}, type: #{inspect(type)}, column: #{inspect(destination_field)}, prefix: \"public\"",
+        "references(:#{table}, type: #{integer_to_bigint(type)}, column: #{
+          inspect(destination_field)
+        }, prefix: \"public\"",
         "name: #{inspect(reference.name)}",
         on_delete(reference),
         on_update(reference),
@@ -329,7 +336,9 @@ defmodule AshPostgres.MigrationGenerator.Operation do
            }
          ) do
       join([
-        "references(:#{table}, type: #{inspect(type)}, column: #{inspect(destination_field)}",
+        "references(:#{table}, type: #{integer_to_bigint(type)}, column: #{
+          inspect(destination_field)
+        }",
         "name: #{inspect(reference.name)}",
         on_delete(reference),
         on_update(reference),

--- a/lib/migration_generator/operation.ex
+++ b/lib/migration_generator/operation.ex
@@ -178,7 +178,7 @@ defmodule AshPostgres.MigrationGenerator.Operation do
     def up(%{attribute: %{type: :integer, default: "nil", generated?: true} = attribute}) do
       [
         "add #{inspect(attribute.name)}",
-        ":serial",
+        ":bigserial",
         maybe_add_null(attribute.allow_nil?),
         maybe_add_primary_key(attribute.primary_key?)
       ]

--- a/test/migration_generator_test.exs
+++ b/test/migration_generator_test.exs
@@ -411,11 +411,11 @@ defmodule AshPostgres.MigrationGeneratorTest do
       :ok
     end
 
-    test "when an integer is generated and default nil, it is a serial" do
+    test "when an integer is generated and default nil, it is a bigserial" do
       assert [file] = Path.wildcard("test_migration_path/**/*_migrate_resources*.exs")
 
       assert File.read!(file) =~
-               ~S[add :id, :serial, null: false, primary_key: true]
+               ~S[add :id, :bigserial, null: false, primary_key: true]
 
       assert File.read!(file) =~
                ~S[add :views, :integer]


### PR DESCRIPTION
### Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests

On my previous PR I modified the integer primary keys to generate a `bigserial` id, while the test was successful I didn't take into account relationships which should be `bigint` as well, so this PR aims to solve that 

My worry here is the lack of tests regarding this, I'm not really familiar with the way you test things here @zachdaniel so a bit of help/guidance would be appreciated ^^/ 