### PR TITLE
improvement: Preserve attribute order

### DIFF
--- a/lib/migration_generator/migration_generator.ex
+++ b/lib/migration_generator/migration_generator.ex
@@ -213,9 +213,7 @@ defmodule AshPostgres.MigrationGenerator do
   end
 
   defp add_order_to_operations({snapshot, operations}) do
-    %{attributes: attributes} = snapshot
-
-    operations_with_order = Enum.map(operations, &add_order_to_operation(&1, attributes))
+    operations_with_order = Enum.map(operations, &add_order_to_operation(&1, snapshot.attributes))
 
     {snapshot, operations_with_order}
   end

--- a/lib/migration_generator/migration_generator.ex
+++ b/lib/migration_generator/migration_generator.ex
@@ -234,6 +234,8 @@ defmodule AshPostgres.MigrationGenerator do
     %{op | new_attribute: attribute}
   end
 
+  defp add_order_to_operation(op, _), do: op
+
   defp organize_operations([]), do: []
 
   defp organize_operations(operations) do

--- a/lib/migration_generator/migration_generator.ex
+++ b/lib/migration_generator/migration_generator.ex
@@ -24,15 +24,7 @@ defmodule AshPostgres.MigrationGenerator do
 
   def generate(apis, opts \\ []) do
     apis = List.wrap(apis)
-
-    opts =
-      case struct(__MODULE__, opts) do
-        %{check_generated: true} = opts ->
-          %{opts | dry_run: true}
-
-        opts ->
-          opts
-      end
+    opts = opts(opts)
 
     all_resources = Enum.flat_map(apis, &Ash.Api.resources/1)
 
@@ -184,7 +176,10 @@ defmodule AshPostgres.MigrationGenerator do
     |> Enum.each(fn {repo, snapshots} ->
       deduped = deduplicate_snapshots(snapshots, opts)
 
-      snapshots_with_operations = fetch_operations(deduped, opts)
+      snapshots_with_operations =
+        deduped
+        |> fetch_operations(opts)
+        |> Enum.map(&add_order_to_operations/1)
 
       snapshots = Enum.map(snapshots_with_operations, &elem(&1, 0))
 
@@ -215,6 +210,28 @@ defmodule AshPostgres.MigrationGenerator do
           |> write_migration!(snapshots, repo, opts, tenant?)
       end
     end)
+  end
+
+  defp add_order_to_operations({snapshot, operations}) do
+    %{attributes: attributes} = snapshot
+
+    operations_with_order = Enum.map(operations, &add_order_to_operation(&1, attributes))
+
+    {snapshot, operations_with_order}
+  end
+
+  defp add_order_to_operation(%{attribute: attribute} = op, attributes) do
+    order = Enum.find_index(attributes, &(&1.name == attribute.name))
+    attribute = Map.put(attribute, :order, order)
+
+    %{op | attribute: attribute}
+  end
+
+  defp add_order_to_operation(%{new_attribute: attribute} = op, attributes) do
+    order = Enum.find_index(attributes, &(&1.name == attribute.name))
+    attribute = Map.put(attribute, :order, order)
+
+    %{op | new_attribute: attribute}
   end
 
   defp organize_operations([]), do: []
@@ -314,6 +331,8 @@ defmodule AshPostgres.MigrationGenerator do
 
   defp merge_attributes(attributes, table, count) do
     attributes
+    |> Enum.with_index()
+    |> Enum.map(fn {attr, i} -> Map.put(attr, :order, i) end)
     |> Enum.group_by(& &1.name)
     |> Enum.map(fn {name, attributes} ->
       %{
@@ -323,9 +342,12 @@ defmodule AshPostgres.MigrationGenerator do
         allow_nil?: Enum.any?(attributes, & &1.allow_nil?) || Enum.count(attributes) < count,
         generated?: Enum.any?(attributes, & &1.generated?),
         references: merge_references(Enum.map(attributes, & &1.references), name, table),
-        primary_key?: false
+        primary_key?: false,
+        order: attributes |> Enum.map(& &1.order) |> Enum.min()
       }
     end)
+    |> Enum.sort(&(&1.order < &2.order))
+    |> Enum.map(&Map.drop(&1, [:order]))
   end
 
   defp merge_references(references, name, table) do
@@ -833,6 +855,12 @@ defmodule AshPostgres.MigrationGenerator do
 
     sort_operations(rest, new_acc)
   end
+
+  defp after?(
+         %Operation.AddAttribute{attribute: %{order: l}, table: table},
+         %Operation.AddAttribute{attribute: %{order: r}, table: table}
+       ),
+       do: l > r
 
   defp after?(
          %Operation.RenameUniqueIndex{
@@ -1520,7 +1548,6 @@ defmodule AshPostgres.MigrationGenerator do
 
     resource
     |> Ash.Resource.Info.attributes()
-    |> Enum.sort_by(& &1.name)
     |> Enum.map(&Map.take(&1, [:name, :type, :default, :allow_nil?, :generated?, :primary_key?]))
     |> Enum.map(fn attribute ->
       default = default(attribute, repo)

--- a/lib/migration_generator/migration_generator.ex
+++ b/lib/migration_generator/migration_generator.ex
@@ -1037,6 +1037,9 @@ defmodule AshPostgres.MigrationGenerator do
        when not is_nil(references),
        do: true
 
+  defp after?(%Operation.AddCheckConstraint{}, _), do: true
+  defp after?(%Operation.RemoveCheckConstraint{}, _), do: true
+
   defp after?(_, _), do: false
 
   defp fetch_operations(snapshots, opts) do


### PR DESCRIPTION
A new PR as I messed up the Git history on the old one. I've deleted the `priv/` folder and run the migrations, but I'm still getting this:

```elixir
def up do
  create table(:posts, primary_key: false) do
    add :id, :uuid, null: false, default: fragment("uuid_generate_v4()"), primary_key: true
    add :title, :text
    add :score, :bigint
    add :public, :boolean
    add :category, :citext
    add :type, :text, default: "sponsored"
    add :price, :bigint
  end

  create constraint(:posts, :price_must_be_positive, check: "type = 'sponsored' AND price > 0")

  alter table(:posts) do
    add :decimal, :decimal, default: 0
    add :status, :status
  end
```