### PR TITLE
improvement: add exclusion_constraint_names

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -7,6 +7,7 @@ locals_without_parens = [
   check_constraint: 3,
   concurrently: 1,
   create?: 1,
+  exclusion_constraint_names: 1,
   foreign_key_names: 1,
   identity_index_names: 1,
   include: 1,

--- a/lib/ash_postgres.ex
+++ b/lib/ash_postgres.ex
@@ -64,6 +64,11 @@ defmodule AshPostgres do
     Extension.get_opt(resource, [:postgres], :unique_index_names, [], true)
   end
 
+  @doc "The configured exclusion_constraint_names"
+  def exclusion_constraint_names(resource) do
+    Extension.get_opt(resource, [:postgres], :exclusion_constraint_names, [], true)
+  end
+
   @doc "The configured identity_index_names"
   def identity_index_names(resource) do
     Extension.get_opt(resource, [:postgres], :identity_index_names, [], true)


### PR DESCRIPTION
Add support for defining the names of pre-existing exclusion constraints in the DB

Signed-off-by: kernel <kernel-io@users.noreply.github.com>

### Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests
