### PR TITLE
improvement: handle fallback ecto migration default elegantly

### DIFF
--- a/lib/ecto_migration_default.ex
+++ b/lib/ecto_migration_default.ex
@@ -13,14 +13,14 @@ defimpl EctoMigrationDefault, for: Any do
 
       `#{inspect(value)}`
 
-    The default value in the migration will be set to `#{inspect(value)}`.
-    This may not be correct, depending on the type, so edit your migration accordingly.
+    The default value in the migration will be set to `nil` and you can edit
+    your migration accordingly.
 
     To prevent this warning, implement the `EctoMigrationDefault` protocol
     for the appropriate Elixir type in your Ash project.
     """)
 
-    inspect(value)
+    "nil # #{inspect(value)}"
   end
 end
 

--- a/lib/ecto_migration_default.ex
+++ b/lib/ecto_migration_default.ex
@@ -20,7 +20,7 @@ defimpl EctoMigrationDefault, for: Any do
     for the appropriate Elixir type in your Ash project.
     """)
 
-    "nil # #{inspect(value)}"
+    "nil"
   end
 end
 

--- a/lib/ecto_migration_default.ex
+++ b/lib/ecto_migration_default.ex
@@ -1,5 +1,27 @@
+require Logger
+
 defprotocol EctoMigrationDefault do
+  @fallback_to_any true
   def to_default(value)
+end
+
+defimpl EctoMigrationDefault, for: Any do
+  def to_default(value) do
+    Logger.warn("""
+    You have specified a default value for a type that cannot be explicitly
+    converted to an Ecto default:
+
+      `#{inspect(value)}`
+
+    The default value in the migration will be set to `#{inspect(value)}`.
+    This may not be correct, depending on the type, so edit your migration accordingly.
+
+    To prevent this warning, implement the `EctoMigrationDefault` protocol
+    for the appropriate Elixir type in your Ash project.
+    """)
+
+    inspect(value)
+  end
 end
 
 defimpl EctoMigrationDefault, for: Integer do

--- a/lib/migration_generator/migration_generator.ex
+++ b/lib/migration_generator/migration_generator.ex
@@ -2010,26 +2010,8 @@ defmodule AshPostgres.MigrationGenerator do
   end
 
   defp default(%{default: {_, _, _}}, _), do: "nil"
-
   defp default(%{default: nil}, _), do: "nil"
-
-  defp default(%{default: value}, _) do
-    if EctoMigrationDefault.impl_for(value) do
-      EctoMigrationDefault.to_default(value)
-    else
-      Logger.warn("""
-      You have specified a default value that cannot be automatically converted to an Ecto default:
-
-        `#{inspect(value)}`
-
-      The default value in the migration will be set to `nil`.
-
-      To resolve this, implement the `EctoMigrationDefault` protocol for the appropriate Elixir type in your Ash project.
-      """)
-
-      "nil"
-    end
-  end
+  defp default(%{default: value}, _), do: EctoMigrationDefault.to_default(value)
 
   defp snapshot_to_binary(snapshot) do
     snapshot

--- a/test/migration_generator_test.exs
+++ b/test/migration_generator_test.exs
@@ -939,7 +939,7 @@ defmodule AshPostgres.MigrationGeneratorTest do
       file = File.read!(file1)
 
       assert file =~
-               ~S[add :product_code, :text, default: {"xyz"}]
+               ~S[add :product_code, :text, default: nil # {"xyz"}]
     end
   end
 end

--- a/test/migration_generator_test.exs
+++ b/test/migration_generator_test.exs
@@ -939,7 +939,7 @@ defmodule AshPostgres.MigrationGeneratorTest do
       file = File.read!(file1)
 
       assert file =~
-               ~S[add :product_code, :text, default: nil # {"xyz"}]
+               ~S[add :product_code, :text]
     end
   end
 end


### PR DESCRIPTION
Instead of hard defaulting to a `nil` default value when there is no
available protocol implementation for the type, we provide a more
sensible default as a protocol fallback.

### Contributor checklist

- [x] Features include unit/acceptance tests
