### PR TITLE
fix: rename attributes correctly in down migration

### DIFF
--- a/lib/migration_generator/operation.ex
+++ b/lib/migration_generator/operation.ex
@@ -606,8 +606,8 @@ defmodule AshPostgres.MigrationGenerator.Operation do
 
     def down(
           %{
-            new_attribute: old_attribute,
-            old_attribute: new_attribute
+            old_attribute: old_attribute,
+            new_attribute: new_attribute
           } = data
         ) do
       up(%{data | new_attribute: old_attribute, old_attribute: new_attribute})

--- a/test/migration_generator_test.exs
+++ b/test/migration_generator_test.exs
@@ -378,7 +378,11 @@ defmodule AshPostgres.MigrationGeneratorTest do
       assert [_file1, file2] =
                Enum.sort(Path.wildcard("test_migration_path/**/*_migrate_resources*.exs"))
 
+      # Up migration
       assert File.read!(file2) =~ ~S[rename table(:posts), :title, to: :subject]
+
+      # Down migration
+      assert File.read!(file2) =~ ~S[rename table(:posts), :subject, to: :title]
     end
 
     test "when renaming a field, it asks which field you are renaming it to, and adds it if you arent" do


### PR DESCRIPTION
### Contributor checklist

- [x] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests

I noticed an issue when generating a migration that renamed an attribute, it was generating migrations that looked like this:

```
defmodule MyApp.Repo.Migrations.MigrateResources36 do
  @moduledoc """
  Updates resources based on their most recent snapshots.

  This file was autogenerated with `mix ash_postgres.generate_migrations`
  """

  use Ecto.Migration

  def up do
    rename table(:element_steps), :description, to: :something_else
  end

  def down do
    rename table(:element_steps), :description, to: :something_else
  end
end
```

And obviously the down migration should rename back the other way. 

I tracked it down to a double-reassign in the migration generator - the `new_attribute` was being stored as `old_attribute` then being passed back as the `new_attribute`, ie. the exact same data. The swapping between new-old attributes only needs to happen once, not twice!