### PR TITLE
fix: Squash dashes in migration names.

### DIFF
--- a/lib/migration_generator/migration_generator.ex
+++ b/lib/migration_generator/migration_generator.ex
@@ -196,7 +196,12 @@ defmodule AshPostgres.MigrationGenerator do
           |> migration_path(repo)
           |> Path.join(migration_name <> ".exs")
 
-        module_name = Module.concat([repo, Migrations, Macro.camelize(module)])
+        sanitized_module =
+          module
+          |> String.replace("-", "_")
+          |> Macro.camelize()
+
+        module_name = Module.concat([repo, Migrations, sanitized_module])
 
         install =
           Enum.map_join(to_install, "\n", fn


### PR DESCRIPTION
I accidentally generated a migration with a dasherised name.  This fixes that.