### PR TITLE
fix: && operator in expressions to point to ash_elixir_and

### DIFF
--- a/lib/expr.ex
+++ b/lib/expr.ex
@@ -476,7 +476,7 @@ defmodule AshPostgres.Expr do
           %Fragment{
             embedded?: pred_embedded?,
             arguments: [
-              raw: "ash_elixir_or(",
+              raw: "ash_elixir_and(",
               casted_expr: left_expr,
               raw: ", ",
               casted_expr: right_expr,

--- a/test/calculation_test.exs
+++ b/test/calculation_test.exs
@@ -93,7 +93,7 @@ defmodule AshPostgres.CalculationTest do
       })
       |> Api.create!()
 
-    assert %{first_name_and_bob: "bob"} =
+    assert %{first_name_and_bob: "fred"} =
              Author
              |> Ash.Query.filter(id == ^author.id)
              |> Ash.Query.load(:first_name_and_bob)

--- a/test/calculation_test.exs
+++ b/test/calculation_test.exs
@@ -88,12 +88,10 @@ defmodule AshPostgres.CalculationTest do
   test "calculations can use the && operator" do
     author =
       Author
-      |> Ash.Changeset.for_create(:create, %{
-        bio: %{first_name: "fred", title: "Mr.", bio: "Bones"}
-      })
+      |> Ash.Changeset.for_create(:create, %{first_name: "fred", bio: %{title: "Mr.", bio: "Bones"}})
       |> Api.create!()
 
-    assert %{first_name_and_bob: "fred"} =
+    assert %{first_name_and_bob: "bob"} =
              Author
              |> Ash.Query.filter(id == ^author.id)
              |> Ash.Query.load(:first_name_and_bob)


### PR DESCRIPTION
### Bug

The `&&` operator was being expanded to `ash_elixir_or` instead of `ash_elixir_and`. Fixed the source and test.

### Contributor checklist

- [x] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests
