### PR TITLE
Failing tests for aggregates on arrays

### DIFF
--- a/test/support/resources/profile.ex
+++ b/test/support/resources/profile.ex
@@ -21,4 +21,8 @@ defmodule AshPostgres.Test.Profile do
   relationships do
     belongs_to(:author, AshPostgres.Test.Author)
   end
+
+  aggregates do
+    first(:author_badges, :author, :badges)
+  end
 end


### PR DESCRIPTION
Refs #120 

Aggregates on array composite types are failing in two ways:

1. When the array contains something, the aggregate results in nil
2. When the array is empty, `ERROR 2202E (array_subscript_error) cannot accumulate empty arrays` is raised