### PR TITLE
fix: Use UTC for default generated timestamps

### DIFF
--- a/lib/migration_generator/migration_generator.ex
+++ b/lib/migration_generator/migration_generator.ex
@@ -2282,7 +2282,7 @@ defmodule AshPostgres.MigrationGenerator do
           ~S[fragment("uuid_generate_v4()")]
 
         default == (&DateTime.utc_now/0) ->
-          ~S[fragment("now()")]
+          ~S[fragment("(now() AT TIME ZONE 'utc')")]
 
         true ->
           "nil"


### PR DESCRIPTION
> In cases where the database server is not set to UTC, this fixes timezone inconsistencies when adding timestamp columns to tables with existing data, that would then have their timestamps set to non-UTC times.

Something I noticed in dev - when adding `inserted_at`/`updated_at` timestamps to a table, it generated a migration that looked like this:

```
    alter table(:posts) do
      add :inserted_at, :utc_datetime_usec, null: false, default: fragment("now()")
      add :updated_at, :utc_datetime_usec, null: false, default: fragment("now()")
    end
```

I am in UTC+8, and I presume my dev database server is as well. So when I ran this migration at 12.01pm local time for an existing table that had data in it, the existing rows had their timestamps set to `2023-02-15 12:01:39.984484`.

However, when inserting records via Ash, the timestamps are converted to UTC before saving. I inserted a record via iex at 1.57pm local time, and the timestamp in the database was saved as `2023-02-15 05:58:04.952904`.

So I think the default value set for the column should be now in UTC, or `fragment("(now() AT TIME ZONE 'utc')")`, instead of just `now()` for consistency.

I tested locally by rolling back the generated migration, updating it to use:

```
    alter table(:posts) do
      add :inserted_at, :utc_datetime_usec,
        null: false,
        default: fragment("(now() AT TIME ZONE 'utc')")

      add :updated_at, :utc_datetime_usec,
        null: false,
        default: fragment("(now() AT TIME ZONE 'utc')")
    end
```

and ran it again, and the timestamps were set in UTC like I expected.

I don't know how one would go about writing a test for this!

### Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests
