### PR TITLE
fix: interpolate table names with `inspect` in generated migrations

### DIFF
--- a/lib/migration_generator/phase.ex
+++ b/lib/migration_generator/phase.ex
@@ -5,9 +5,11 @@ defmodule AshPostgres.MigrationGenerator.Phase do
     @moduledoc false
     defstruct [:table, :schema, :multitenancy, operations: [], commented?: false]
 
+    import AshPostgres.MigrationGenerator.Operation.Helper, only: [as_atom: 1]
+
     def up(%{schema: schema, table: table, operations: operations, multitenancy: multitenancy}) do
       if multitenancy.strategy == :context do
-        "create table(:#{table}, primary_key: false, prefix: prefix()) do\n" <>
+        "create table(:#{as_atom(table)}, primary_key: false, prefix: prefix()) do\n" <>
           Enum.map_join(operations, "\n", fn operation -> operation.__struct__.up(operation) end) <>
           "\nend"
       else
@@ -18,7 +20,7 @@ defmodule AshPostgres.MigrationGenerator.Phase do
             ""
           end
 
-        "create table(:#{table}, primary_key: false#{opts}) do\n" <>
+        "create table(:#{as_atom(table)}, primary_key: false#{opts}) do\n" <>
           Enum.map_join(operations, "\n", fn operation -> operation.__struct__.up(operation) end) <>
           "\nend"
       end
@@ -26,7 +28,7 @@ defmodule AshPostgres.MigrationGenerator.Phase do
 
     def down(%{schema: schema, table: table, multitenancy: multitenancy}) do
       if multitenancy.strategy == :context do
-        "drop table(:#{inspect(table)}, prefix: prefix())"
+        "drop table(:#{as_atom(table)}, prefix: prefix())"
       else
         opts =
           if schema do
@@ -35,7 +37,7 @@ defmodule AshPostgres.MigrationGenerator.Phase do
             ""
           end
 
-        "drop table(:#{inspect(table)}#{opts})"
+        "drop table(:#{as_atom(table)}#{opts})"
       end
     end
   end
@@ -44,12 +46,14 @@ defmodule AshPostgres.MigrationGenerator.Phase do
     @moduledoc false
     defstruct [:schema, :table, :multitenancy, operations: [], commented?: false]
 
+    import AshPostgres.MigrationGenerator.Operation.Helper, only: [as_atom: 1]
+
     def up(%{table: table, schema: schema, operations: operations, multitenancy: multitenancy}) do
       body =
         Enum.map_join(operations, "\n", fn operation -> operation.__struct__.up(operation) end)
 
       if multitenancy.strategy == :context do
-        "alter table(:#{table}, prefix: prefix()) do\n" <>
+        "alter table(:#{as_atom(table)}, prefix: prefix()) do\n" <>
           body <>
           "\nend"
       else
@@ -60,7 +64,7 @@ defmodule AshPostgres.MigrationGenerator.Phase do
             ""
           end
 
-        "alter table(:#{table}#{opts}) do\n" <>
+        "alter table(:#{as_atom(table)}#{opts}) do\n" <>
           body <>
           "\nend"
       end
@@ -73,7 +77,7 @@ defmodule AshPostgres.MigrationGenerator.Phase do
         |> Enum.map_join("\n", fn operation -> operation.__struct__.down(operation) end)
 
       if multitenancy.strategy == :context do
-        "alter table(:#{table}, prefix: prefix()) do\n" <>
+        "alter table(:#{as_atom(table)}, prefix: prefix()) do\n" <>
           body <>
           "\nend"
       else
@@ -84,7 +88,7 @@ defmodule AshPostgres.MigrationGenerator.Phase do
             ""
           end
 
-        "alter table(:#{table}#{opts}) do\n" <>
+        "alter table(:#{as_atom(table)}#{opts}) do\n" <>
           body <>
           "\nend"
       end


### PR DESCRIPTION
Currently in `MigrationGenerator.Phase` a table name interpolated as simply `:#{table}` for `Create.up`, `Alter.up/down`, but in `Create.down` it is done as `:#{inspect(table)}`. If a table name contains non-word letters then without that inspect call the result may end up being an invalid code - `:auth.tokens` (if the table name is "auth.tokens") versus legal `:"auth.tokens"`.

Seems like having non-word letters might be a bad idea, still, a simple fix.