### PR TITLE
fix: fix Logger deprecations for elixir 1.15

### DIFF
--- a/lib/ecto_migration_default.ex
+++ b/lib/ecto_migration_default.ex
@@ -13,7 +13,7 @@ defimpl EctoMigrationDefault, for: Any do
   require Logger
 
   def to_default(value) do
-    Logger.warn("""
+    Logger.warning("""
     You have specified a default value for a type that cannot be explicitly
     converted to an Ecto default:
 


### PR DESCRIPTION
Use Logger.warning instead of Logger.warn, [which is deprecated as of elixir 1.15](https://github.com/elixir-lang/elixir/blob/v1.15/CHANGELOG.md#logger-2).

Logger.warning [is available since elixir 1.11](https://hexdocs.pm/logger/1.15.0/Logger.html#warning/2), and since [this project requires at least elixir 1.11](https://github.com/ash-project/ash_postgres/blob/main/mix.exs#L15), this is a safe change.
