### PR TITLE
Add test, that shows bug when filtering on exists calc on related resource

### DIFF
--- a/test/calculation_test.exs
+++ b/test/calculation_test.exs
@@ -58,6 +58,11 @@ defmodule AshPostgres.CalculationTest do
              Post
              |> Ash.Query.filter(c_times_p == 6)
              |> Api.read!()
+
+    assert [] =
+             Post
+             |> Ash.Query.filter(author: [has_posts: true])
+             |> Api.read!()
   end
 
   test "calculations can refer to to_one path attributes in filters" do

--- a/test/support/resources/author.ex
+++ b/test/support/resources/author.ex
@@ -92,5 +92,7 @@ defmodule AshPostgres.Test.Author do
               {AshPostgres.Test.Concat, keys: [:first_name, :last_name]} do
       argument(:separator, :string, default: " ", constraints: [allow_empty?: true, trim?: false])
     end
+
+    calculate :has_posts, :boolean, expr(exists(posts, true))
   end
 end


### PR DESCRIPTION
I ran into this error problem today and spent several hours reviewing the code. 

I was able to narrow it down to somewhere around here:

https://github.com/ash-project/ash_postgres/blob/944a4e128eef25fe3531964bceb23e916d66fbed/lib/expr.ex#L1027

I tried to update the `at_path` property of the `exists` with the relationship path, but afterwards, I still got an error because the parent in the constructed subquery was `nil`. 

I added this after `Ash.Filter.update_aggregates(...)`

```elixir
    |> update_exists(fn exists ->
            %{exists | at_path: relationship_path || []}
          end),

.....

  defp update_exists(expression, mapper) do
    case expression do
      %{__function__?: true, arguments: args} = func ->
        %{func | arguments: Enum.map(args, &update_exists(&1, mapper))}

      %Exists{} = exists ->
        mapper.(exists)

      other ->
        other
    end
  end
```

I'm guessing I would also need to add a binding somehow, but I'm having a hard time fully grasping all that is happening here :exploding_head: :rofl: 

At this point, I would be grateful for some help with the problem. 
