### PR TITLE
fix: keep fields of `custom_index` in format that they were provided

### DIFF
--- a/lib/aggregate.ex
+++ b/lib/aggregate.ex
@@ -77,7 +77,7 @@ defmodule AshPostgres.Aggregate do
               first_relationship =
                 case Ash.Resource.Info.relationship(resource, first_relationship) do
                   nil ->
-                    raise "No such relationship for #{inspect(first_relationship)} aggregates #{inspect aggregates}"
+                    raise "No such relationship for #{inspect(first_relationship)} aggregates #{inspect(aggregates)}"
 
                   first_relationship ->
                     first_relationship

--- a/lib/custom_index.ex
+++ b/lib/custom_index.ex
@@ -67,20 +67,7 @@ defmodule AshPostgres.CustomIndex do
 
   def schema, do: @schema
 
-  # sobelow_skip ["DOS.StringToAtom"]
-  def transform(%__MODULE__{fields: fields} = index) do
-    index = %{
-      index
-      | fields:
-          Enum.map(fields, fn field ->
-            if is_atom(field) do
-              field
-            else
-              String.to_atom(field)
-            end
-          end)
-    }
-
+  def transform(index) do
     cond do
       index.name ->
         if Regex.match?(~r/^[0-9a-zA-Z_]+$/, index.name) do

--- a/lib/join.ex
+++ b/lib/join.ex
@@ -205,7 +205,7 @@ defmodule AshPostgres.Join do
     relationship = Ash.Resource.Info.relationship(resource, name)
 
     if !relationship do
-      raise "no such relationship #{inspect resource}.#{name}"
+      raise "no such relationship #{inspect(resource)}.#{name}"
     end
 
     relationship_path_to_relationships(relationship.destination, rest, [relationship | acc])
@@ -307,7 +307,9 @@ defmodule AshPostgres.Join do
         if Enum.empty?(query.joins) || is_subquery? do
           {:ok, query, acc}
         else
-          {:ok, (from row in subquery(query), []) |> Map.put(:__ash_bindings__, query.__ash_bindings__), acc}
+          {:ok,
+           from(row in subquery(query), []) |> Map.put(:__ash_bindings__, query.__ash_bindings__),
+           acc}
         end
 
       {:error, error} ->

--- a/test/migration_generator_test.exs
+++ b/test/migration_generator_test.exs
@@ -294,7 +294,7 @@ defmodule AshPostgres.MigrationGeneratorTest do
 
       assert file =~ ~S[@disable_ddl_transaction true]
 
-      assert file =~ ~S<create index(:posts, ["title"], concurrently: true)>
+      assert file =~ ~S<create index(:posts, [:title], concurrently: true)>
     end
   end
 


### PR DESCRIPTION
Right now fields of `custom_index` are first transformed into atoms and then during migration generation into strings. 

I used a field named "order" and encountered an error because of this. Ecto generates different statements depending on whenever a field was provided as a string or as an atom:
```elixir
create index(:some_table, ["order"]) # invalid
create index(:some_table, [:order]) # valid
```
For atoms the resulting name will be in quotes, for strings they will be left as is (and it, for example, allows specifying things like `"name gin_trgm_ops"` for full-text search usage).

So it makes sense to keep user provided input as is and not convert it into atoms or strings.

Also made `RemoveCustomIndex` operation to use reverse direction of `AddCustomIndex` to avoid repetition.