### PR TITLE
fix: Correct the matching used in building a distinct expression

### DIFF
--- a/lib/data_layer.ex
+++ b/lib/data_layer.ex
@@ -2573,7 +2573,7 @@ defmodule AshPostgres.DataLayer do
 
   def distinct(query, distinct_on, resource) do
     case get_distinct_statement(query, distinct_on) do
-      {:ok, distinct_statement, query} ->
+      {:ok, {distinct_statement, query}} ->
         %{query | distinct: distinct_statement}
         |> apply_sort(query.__ash_bindings__[:sort], resource)
 
@@ -2692,7 +2692,7 @@ defmodule AshPostgres.DataLayer do
 
           distinct_on, {[order_by | rest_order_by], distinct_statement, params, count, query} ->
             case order_by do
-              {^distinct_on, order} ->
+              {distinct_on, order} = ^distinct_on ->
                 {distinct_expr, params, count, query} =
                   distinct_on_expr(query, distinct_on, params, count)
 
@@ -2710,11 +2710,11 @@ defmodule AshPostgres.DataLayer do
 
           {_, result, params, _, query} ->
             {:ok,
-             %{
-               distinct
-               | expr: distinct.expr ++ Enum.reverse(result),
-                 params: distinct.params ++ Enum.reverse(params)
-             }, query}
+             {%{
+                distinct
+                | expr: distinct.expr ++ Enum.reverse(result),
+                  params: distinct.params ++ Enum.reverse(params)
+              }, query}}
         end
       end
     end

--- a/test/distinct_test.exs
+++ b/test/distinct_test.exs
@@ -168,4 +168,13 @@ defmodule AshPostgres.DistinctTest do
              %{title: "title", negative_score: -1}
            ] = results
   end
+
+  test "distinct used on it's own" do
+    results =
+      Post
+      |> Ash.Query.distinct(:title)
+      |> Api.read!()
+
+    assert [_, _] = results
+  end
 end


### PR DESCRIPTION
When upgrading dependencies on my project recently, one of our queries started to fail with a `no case clause matching` error. The query in question had a simple filter with a distinct clause and *no* sort clause. 
Basically, I found that the shape of the return in `DataLayer.get_distinct_statement` was inconsistent. I created a test that exposed the issue with the distinct alone. And while I was making sure all exit paths were accounted for I noticed that the success path in the `reduce_while` was never ran, the fallback was always used: 
```elixir
distinct_on
|> Enum.reduce_while({sort, [], [], Enum.count(distinct.params), query}, fn
  _, {[], _distinct_statement, _, _count, _query} ->
    {:halt, :error}

  distinct_on, {[order_by | rest_order_by], distinct_statement, params, count, query} ->
    case order_by do
      {^distinct_on, order}  -> ######### Never matched here
        {distinct_expr, params, count, query} =
          distinct_on_expr(query, distinct_on, params, count)

        {:cont,
         {rest_order_by, [{order, distinct_expr} | distinct_statement], params, count,
          query}}

      _ -> ######### Always matched here
        {:halt, :error}
    end
end)
```

Let me know if there's anything else I may have missed.


### Contributor checklist

- [X] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests
