### PR TITLE
test: add failing test to demo bug with changeset loading related data

### DIFF
--- a/test/manual_update_test.exs
+++ b/test/manual_update_test.exs
@@ -7,11 +7,21 @@ defmodule AshPostgres.ManualUpdateTest do
       |> Ash.Changeset.new(%{title: "match"})
       |> AshPostgres.Test.Api.create!()
 
+    AshPostgres.Test.Comment
+    |> Ash.Changeset.new(%{title: "_"})
+    |> Ash.Changeset.manage_relationship(:post, post, type: :append_and_remove)
+    |> AshPostgres.Test.Api.create!()
+
     post =
       post
       |> Ash.Changeset.for_update(:manual_update)
       |> AshPostgres.Test.Api.update!()
 
     assert post.title == "manual"
+
+    # The manual update has a call to Ash.Changeset.load that should
+    # cause the comments to be loaded
+    assert Ash.Resource.loaded?(post, :comments)
+    assert Enum.count(post.comments) == 1
   end
 end

--- a/test/support/resources/post.ex
+++ b/test/support/resources/post.ex
@@ -453,6 +453,7 @@ defmodule AshPostgres.Test.Post.ManualUpdate do
       changeset.data
       |> Ash.Changeset.for_update(:update, changeset.attributes)
       |> Ash.Changeset.force_change_attribute(:title, "manual")
+      |> Ash.Changeset.load(:comments)
       |> AshPostgres.Test.Api.update!()
     }
   end


### PR DESCRIPTION
Add a failing test to demonstrate an issue recently introduced, where calling `Ash.Changeset.load` does not work.