### PR TITLE
Include modules in installed_extensions return type

### DIFF
--- a/lib/repo.ex
+++ b/lib/repo.ex
@@ -42,7 +42,7 @@ defmodule AshPostgres.Repo do
   """
 
   @doc "Use this to inform the data layer about what extensions are installed"
-  @callback installed_extensions() :: [String.t()]
+  @callback installed_extensions() :: [String.t() | module()]
 
   @doc """
   Use this to inform the data layer about the oldest potential postgres version it will be run on.


### PR DESCRIPTION
As per the documentation (and indeed the actual behavior):

> Extensions can be a string, representing a standard postgres
extension, or a module that implements `AshPostgres.CustomExtension`.

### Contributor checklist

This doesn't affect runtime behavior. Testing against type-related warnings for supported scenarios might be worthwhile, but it seems outside of the reasonable scope of this fix. Happy to add tests if there is a reasonable quick path to that.

- [ ] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests
