### PR TITLE
add test for parent in relationship filter

### DIFF
--- a/test/rel_with_parent_filter_test.exs
+++ b/test/rel_with_parent_filter_test.exs
@@ -1,0 +1,52 @@
+defmodule AshPostgres.RelWithParentFilterTest do
+  use AshPostgres.RepoCase, async: false
+
+  alias AshPostgres.Test.{Api, Author}
+
+  require Ash.Query
+
+  test "filter on relationship using parent works as expected when used in aggregate" do
+    %{id: author_id} =
+      Author
+      |> Ash.Changeset.for_create(:create, %{first_name: "John", last_name: "Doe"})
+      |> Api.create!()
+
+    Author
+    |> Ash.Changeset.for_create(:create, %{first_name: "John"})
+    |> Api.create!()
+
+    Logger.configure(level: :debug)
+
+    # here we get the expected result of 1 because it is done in the same query
+    assert %{num_of_authors_with_same_first_name: 1} =
+             Author
+             |> Ash.Query.for_read(:read)
+             |> Ash.Query.filter(id == ^author_id)
+             |> Ash.Query.load(:num_of_authors_with_same_first_name)
+             |> Api.read_one!()
+  end
+
+  test "filter on relationship using parent works as expected when loading relationship" do
+    %{id: author_id} =
+      Author
+      |> Ash.Changeset.for_create(:create, %{first_name: "John", last_name: "Doe"})
+      |> Api.create!()
+
+    Author
+    |> Ash.Changeset.for_create(:create, %{first_name: "John"})
+    |> Api.create!()
+
+    assert %{authors_with_same_first_name: authors} =
+             Author
+             |> Ash.Query.for_read(:read)
+             |> Ash.Query.filter(id == ^author_id)
+             # right now it first loads the contact
+             # then it loads the relationship
+             # but when doing that it does a inner lateral join
+             # instead of using the id from the parent relationship
+             |> Ash.Query.load(:authors_with_same_first_name)
+             |> Api.read_one!()
+
+    assert length(authors) == 1
+  end
+end

--- a/test/support/resources/author.ex
+++ b/test/support/resources/author.ex
@@ -34,6 +34,12 @@ defmodule AshPostgres.Test.Author do
   relationships do
     has_one(:profile, AshPostgres.Test.Profile)
     has_many(:posts, AshPostgres.Test.Post)
+
+    has_many :authors_with_same_first_name, __MODULE__ do
+      source_attribute(:first_name)
+      destination_attribute(:first_name)
+      filter(expr(parent(id) != id))
+    end
   end
 
   aggregates do
@@ -122,5 +128,7 @@ defmodule AshPostgres.Test.Author do
     count :count_of_posts_with_better_comment, [:posts, :comments] do
       join_filter([:posts, :comments], expr(parent(score) < likes))
     end
+
+    count(:num_of_authors_with_same_first_name, :authors_with_same_first_name)
   end
 end


### PR DESCRIPTION
Added a test for something we tried in our application, but didn't get the expected output. 

Not sure if we didn't understand `parent` correctly or if it is a bug. At least the aggregate result differs from what is returned when loading the relationship, which seems a bit inconsistent.