### PR TITLE
fix: use proper tables in joins originating from polymorphic resource

### DIFF
--- a/lib/join.ex
+++ b/lib/join.ex
@@ -232,6 +232,7 @@ defmodule AshPostgres.Join do
     |> Ash.Query.new(nil, base_filter?: false)
     |> Ash.Query.set_context(%{data_layer: %{start_bindings_at: start_binding}})
     |> Ash.Query.set_context(context)
+    |> Ash.Query.set_context(%{data_layer: %{table: nil}})
     |> Ash.Query.set_context(relationship.context)
     |> Ash.Query.for_read(read_action, %{},
       actor: context[:private][:actor],


### PR DESCRIPTION
`context` is taken from a root query. If a root query is of polymorphic resource then it will contain `data_layer.table`. It should not be propagated into context of a join subquery otherwise it will use a root resource table for a related resource.