### PR TITLE
Add nulls_distinct option to CustomIndex

### DIFF
--- a/lib/custom_index.ex
+++ b/lib/custom_index.ex
@@ -11,6 +11,7 @@ defmodule AshPostgres.CustomIndex do
     :prefix,
     :where,
     :include,
+    :nulls_distinct,
     :message,
     :all_tenants?
   ]
@@ -54,14 +55,18 @@ defmodule AshPostgres.CustomIndex do
       type: :string,
       doc: "specify conditions for a partial index."
     ],
-    message: [
-      type: :string,
-      doc: "A custom message to use for unique indexes that have been violated"
-    ],
     include: [
       type: {:list, :string},
       doc:
         "specify fields for a covering index. This is not supported by all databases. For more information on PostgreSQL support, please read the official docs."
+    ],
+    nulls_distinct: [
+      type: :boolean,
+      doc: "specify whether null values should be considered distinct for a unique index."
+    ],
+    message: [
+      type: :string,
+      doc: "A custom message to use for unique indexes that have been violated"
     ],
     all_tenants?: [
       type: :boolean,

--- a/lib/migration_generator/operation.ex
+++ b/lib/migration_generator/operation.ex
@@ -908,6 +908,7 @@ defmodule AshPostgres.MigrationGenerator.Operation do
           option(:prefix, index.prefix),
           option(:where, index.where),
           option(:include, index.include),
+          option(:nulls_distinct, index.nulls_distinct),
           option(:prefix, schema)
         ])
 


### PR DESCRIPTION
### Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests

I was unable to write tests due to a lack of references for testing the CustomIndex module. Descriptions related to nulls_distinct can be found in the document below.

https://hexdocs.pm/ecto_sql/3.9.0/Ecto.Migration.html#index/2