### PR TITLE
Fix default of nulls_distinct option to true

### DIFF
--- a/lib/custom_index.ex
+++ b/lib/custom_index.ex
@@ -63,7 +63,7 @@ defmodule AshPostgres.CustomIndex do
     nulls_distinct: [
       type: :boolean,
       doc: "specify whether null values should be considered distinct for a unique index.",
-      default: false
+      default: true
     ],
     message: [
       type: :string,

--- a/lib/migration_generator/migration_generator.ex
+++ b/lib/migration_generator/migration_generator.ex
@@ -2988,7 +2988,7 @@ defmodule AshPostgres.MigrationGenerator do
         end)
       end)
       |> Map.put_new(:include, [])
-      |> Map.put_new(:nulls_distinct, false)
+      |> Map.put_new(:nulls_distinct, true)
       |> Map.put_new(:message, nil)
       |> Map.put_new(:all_tenants?, false)
     end)

--- a/lib/migration_generator/operation.ex
+++ b/lib/migration_generator/operation.ex
@@ -30,6 +30,12 @@ defmodule AshPostgres.MigrationGenerator.Operation do
     # sobelow_skip ["DOS.StringToAtom"]
     def as_atom(value), do: Macro.inspect_atom(:remote_call, String.to_atom(value))
 
+    def option(:nulls_distinct = key, value) do
+      if !value do
+        "#{as_atom(key)}: #{inspect(value)}"
+      end
+    end
+
     def option(key, value) do
       if value do
         "#{as_atom(key)}: #{inspect(value)}"

--- a/test/migration_generator_test.exs
+++ b/test/migration_generator_test.exs
@@ -298,7 +298,7 @@ defmodule AshPostgres.MigrationGeneratorTest do
     end
   end
 
-  describe "custom_indexes with `null_distinct: true`" do
+  describe "custom_indexes with `null_distinct: false`" do
     setup do
       on_exit(fn ->
         File.rm_rf!("test_snapshots_path")
@@ -337,8 +337,8 @@ defmodule AshPostgres.MigrationGeneratorTest do
 
       file = File.read!(custom_index_migration)
 
-      assert file =~ ~S<create index(:posts, [:uniq_one], nulls_distinct: true)>
-      assert file =~ ~S<create index(:posts, [:uniq_two])>
+      assert file =~ ~S<create index(:posts, [:uniq_one])>
+      assert file =~ ~S<create index(:posts, [:uniq_two], nulls_distinct: false)>
       assert file =~ ~S<create index(:posts, [:uniq_custom_one])>
     end
   end


### PR DESCRIPTION
### Contributor checklist

- [x] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests


I'm so sorry that I misunderstood `nulls_distinct` option in #221.
This PR fix the defulat of `nulls_distinct` option to `true`.