### PR TITLE
feat: test with calculations using `exists`

### DIFF
--- a/test/support/resources/post.ex
+++ b/test/support/resources/post.ex
@@ -265,6 +265,10 @@ defmodule AshPostgres.Test.Post do
       )
     )
 
+    calculate(:has_author, :boolean, expr(exists(author, true == true)))
+
+    calculate(:has_comments, :boolean, expr(exists(comments, true == true)))
+
     calculate(
       :has_no_followers,
       :boolean,


### PR DESCRIPTION
# Test Coverage

Additional test that only increases test coverage.

I encountered a weird behaviour in our code base where a `caluclation` using an `exists` as defined in this PR would not return `true` even if the relation exists.

I wrote a test case directly in `ash_postgres` trying to reproduce the behaviour. However, I could not reproduce it. The test case now only serves to increase the test coverage and proves that the features behaves as expected.