### PR TITLE
align ash.codegen params with current version

### DIFF
--- a/documentation/tutorials/get-started-with-postgres.md
+++ b/documentation/tutorials/get-started-with-postgres.md
@@ -190,7 +190,7 @@ First, we'll create the database with `mix ash.setup`.
 Then we will generate database migrations. This is one of the many ways that AshPostgres can save time and reduce complexity.
 
 ```bash
-mix ash.codegen --name add_tickets_and_representatives
+mix ash.codegen add_tickets_and_representatives
 ```
 
 If you are unfamiliar with database migrations, it is a good idea to get a rough idea of what they are and how they work. See the links at the bottom of this guide for more. A rough overview of how migrations work is that each time you need to make changes to your database, they are saved as small, reproducible scripts that can be applied in order. This is necessary both for clean deploys as well as working with multiple developers making changes to the structure of a single database.


### PR DESCRIPTION
using the --name attribute gives the following error:

```
mix ash.codegen --name add_representatives_and_relations
Getting extensions in current project...
Running codegen for AshPostgres.DataLayer...
warning: Name must be provided when generating migrations, unless `--dry-run` or `--check` is also provided.
Using an autogenerated name will be deprecated in a future release.

Please provide a name. for example:

    mix ash_postgres.generate_migrations <name> 

  (ash_postgres 2.0.0-rc.10) lib/mix/tasks/ash_postgres.generate_migrations.ex:112: Mix.Tasks.AshPostgres.GenerateMigrations.run/1
  (mix 1.16.2) lib/mix/task.ex:478: anonymous fn/3 in Mix.Task.run_task/5
  (elixir 1.16.2) lib/enum.ex:1700: Enum."-map/2-lists^map/1-1-"/2
  (elixir 1.16.2) lib/enum.ex:1700: Enum."-map/2-lists^map/1-1-"/2
  (mix 1.16.2) lib/mix/task.ex:478: anonymous fn/3 in Mix.Task.run_task/5
  (mix 1.16.2) lib/mix/cli.ex:96: Mix.CLI.run_task/2


Extension Migrations: 
No extensions to install

Generating Tenant Migrations: 

Generating Migrations:
* creating priv/repo/migrations/20240424124237_migrate_resources2.exs
```

This PR fixes the warning