### PR TITLE
chore: add failing test for bulk actions and non-null violations

### DIFF
--- a/test/bulk_create_test.exs
+++ b/test/bulk_create_test.exs
@@ -1,6 +1,6 @@
 defmodule AshPostgres.BulkCreateTest do
   use AshPostgres.RepoCase, async: false
-  alias AshPostgres.Test.Post
+  alias AshPostgres.Test.{Post, Record}
 
   describe "bulk creates" do
     test "bulk creates insert each input" do
@@ -203,6 +203,18 @@ defmodule AshPostgres.BulkCreateTest do
                  return_errors?: true
                )
                |> Enum.to_list()
+    end
+
+    test "handle allow_nil? false correctly" do
+      assert %{
+               errors: [
+                 %Ash.Error.Invalid{errors: [%Ash.Error.Changes.Required{field: :full_name}]}
+               ]
+             } =
+               Ash.bulk_create([%{full_name: ""}], Record, :create,
+                 return_records?: true,
+                 return_errors?: true
+               )
     end
   end
 

--- a/test/bulk_update_test.exs
+++ b/test/bulk_update_test.exs
@@ -1,6 +1,6 @@
 defmodule AshPostgres.BulkUpdateTest do
   use AshPostgres.RepoCase, async: false
-  alias AshPostgres.Test.Post
+  alias AshPostgres.Test.{Post, Record}
 
   require Ash.Expr
   require Ash.Query
@@ -128,5 +128,39 @@ defmodule AshPostgres.BulkUpdateTest do
         return_records?: true
       )
     end
+  end
+
+  test "bulk updates return error for null value if allow_nil? false with strategy :stream" do
+    Ash.bulk_create!([%{full_name: "foo"}], Record, :create)
+
+    assert %Ash.BulkResult{
+             error_count: 1,
+             errors: [
+               %Ash.Error.Invalid{errors: [%Ash.Error.Changes.Required{field: :full_name}]}
+             ]
+           } =
+             Ash.bulk_update(Record, :update, %{full_name: ""},
+               strategy: :stream,
+               return_records?: true,
+               return_errors?: true,
+               authorize?: false
+             )
+  end
+
+  test "bulk updates return error for null value if allow_nil? false with strategy :atomic" do
+    Ash.bulk_create!([%{full_name: "foo"}], Record, :create)
+
+    assert %Ash.BulkResult{
+             error_count: 1,
+             errors: [
+               %Ash.Error.Invalid{errors: [%Ash.Error.Changes.Required{field: :full_name}]}
+             ]
+           } =
+             Ash.bulk_update(Record, :update, %{full_name: ""},
+               strategy: :atomic,
+               return_records?: true,
+               return_errors?: true,
+               authorize?: false
+             )
   end
 end

--- a/test/support/resources/record.ex
+++ b/test/support/resources/record.ex
@@ -34,6 +34,6 @@ defmodule AshPostgres.Test.Record do
   actions do
     default_accept(:*)
 
-    defaults([:create, :read])
+    defaults([:create, :read, :update])
   end
 end


### PR DESCRIPTION
- bulk_create returns a Postgrex error instead of Ash.Error.Changes.Required like the non-bulk create does
- bulk_update with :stream strategy does the same
- bulk_update with :atomic strategy doesn't trim the empty string and writes it to the database

### Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests
