### PR TITLE
show error with calc depending on other exists calc

### DIFF
--- a/test/calculation_test.exs
+++ b/test/calculation_test.exs
@@ -59,6 +59,8 @@ defmodule AshPostgres.CalculationTest do
              |> Ash.Query.filter(c_times_p == 6)
              |> Ash.read!()
 
+    Logger.configure(level: :debug)
+
     assert [] =
              Post
              |> Ash.Query.filter(author: [has_posts: true])
@@ -131,6 +133,13 @@ defmodule AshPostgres.CalculationTest do
              Post
              |> Ash.Query.load([:has_author, :has_comments])
              |> Ash.read!()
+
+    # building on top of an exists also works
+    author =
+      author |> Ash.load!([:has_posts, :has_no_posts])
+
+    assert author.has_posts
+    refute author.has_no_posts
   end
 
   test "calculations can refer to embedded attributes" do

--- a/test/support/resources/author.ex
+++ b/test/support/resources/author.ex
@@ -130,7 +130,8 @@ defmodule AshPostgres.Test.Author do
       argument(:separator, :string, default: " ", constraints: [allow_empty?: true, trim?: false])
     end
 
-    calculate(:has_posts, :boolean, expr(exists(posts, true)))
+    calculate(:has_posts, :boolean, expr(exists(posts, true == true)))
+    calculate(:has_no_posts, :boolean, expr(has_posts == false))
   end
 
   aggregates do


### PR DESCRIPTION
In this case the exist is only loaded in the state of the second calculation and the result is used for both. 