### PR TITLE
fix: remove duplicate repo flags

### DIFF
--- a/lib/mix/tasks/ash_postgres.rollback.ex
+++ b/lib/mix/tasks/ash_postgres.rollback.ex
@@ -71,6 +71,7 @@ defmodule Mix.Tasks.AshPostgres.Rollback do
       |> AshPostgres.Mix.Helpers.delete_flag("--tenants")
       |> AshPostgres.Mix.Helpers.delete_flag("--only-tenants")
       |> AshPostgres.Mix.Helpers.delete_flag("--except-tenants")
+      |> AshPostgres.Mix.Helpers.delete_arg("-r")
 
     Mix.Task.reenable("ecto.rollback")
 


### PR DESCRIPTION
### Reproduce Bug
- When using mix command: `mix ash.rollback` and then enter 1 ash_postgres.rollback doing 2 step rollback.
- Or use ash_postgres rollback with repo defined : `mix ash_postgres.rollback -r MyApp.Repo`


### Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests
