### PR TITLE
improvement: support `on_delete: :nilify` for specific columns

### DIFF
--- a/documentation/dsls/DSL:-AshPostgres.DataLayer.md
+++ b/documentation/dsls/DSL:-AshPostgres.DataLayer.md
@@ -258,7 +258,7 @@ end
 
 | Name | Type | Default | Docs |
 |------|------|---------|------|
-| [`polymorphic_on_delete`](#postgres-references-polymorphic_on_delete){: #postgres-references-polymorphic_on_delete } | `:delete \| :nilify \| :nothing \| :restrict` |  | For polymorphic resources, configures the on_delete behavior of the automatically generated foreign keys to source tables. |
+| [`polymorphic_on_delete`](#postgres-references-polymorphic_on_delete){: #postgres-references-polymorphic_on_delete } | `:delete \| :nilify \| {:nilify, columns} \| :nothing \| :restrict` |  | For polymorphic resources, configures the on_delete behavior of the automatically generated foreign keys to source tables. |
 | [`polymorphic_on_update`](#postgres-references-polymorphic_on_update){: #postgres-references-polymorphic_on_update } | `:update \| :nilify \| :nothing \| :restrict` |  | For polymorphic resources, configures the on_update behavior of the automatically generated foreign keys to source tables. |
 
 
@@ -297,7 +297,7 @@ reference :post, on_delete: :delete, on_update: :update, name: "comments_to_post
 | Name | Type | Default | Docs |
 |------|------|---------|------|
 | [`ignore?`](#postgres-references-reference-ignore?){: #postgres-references-reference-ignore? } | `boolean` |  | If set to true, no reference is created for the given relationship. This is useful if you need to define it in some custom way |
-| [`on_delete`](#postgres-references-reference-on_delete){: #postgres-references-reference-on_delete } | `:delete \| :nilify \| :nothing \| :restrict` |  | What should happen to records of this resource when the referenced record of the *destination* resource is deleted. |
+| [`on_delete`](#postgres-references-reference-on_delete){: #postgres-references-reference-on_delete } | `:delete \| :nilify \| {:nilify, columns} \| :nothing \| :restrict` |  | What should happen to records of this resource when the referenced record of the *destination* resource is deleted. |
 | [`on_update`](#postgres-references-reference-on_update){: #postgres-references-reference-on_update } | `:update \| :nilify \| :nothing \| :restrict` |  | What should happen to records of this resource when the referenced destination_attribute of the *destination* record is update. |
 | [`deferrable`](#postgres-references-reference-deferrable){: #postgres-references-reference-deferrable } | `false \| true \| :initially` | `false` | Wether or not the constraint is deferrable. This only affects the migration generator. |
 | [`name`](#postgres-references-reference-name){: #postgres-references-reference-name } | `String.t` |  | The name of the foreign key to generate in the database. Defaults to <table>_<source_attribute>_fkey |

--- a/documentation/topics/resources/references.md
+++ b/documentation/topics/resources/references.md
@@ -14,6 +14,36 @@ end
 >
 > No resource logic is applied with these operations! No authorization rules or validations take place, and no notifications are issued. This operation happens _directly_ in the database.
 
+## On Delete
+
+This option describes what to do if the referenced row is deleted.
+
+The option is called `on_delete`, instead of `on_destroy`, because it is hooking into the database level deletion, _not_ a `destroy` action in your resource. See the warning above.
+
+The possible values for the option are `:nothing`, `:restrict`, `:delete`, `:nilify`, `{:nilify, columns}`.
+
+With `:nothing` or `:restrict` the deletion of the referenced row is prevented.
+
+With `:delete` the row is deleted together with the referenced row.
+
+With `:nilify` all columns of the foreign-key constraint are nilified.
+
+With `{:nilify, columns}` a column list can specify which columns should be set to `nil`.
+If you intend to use this option to nilify a subset of the columns, note that it cannot be used together with the `match: :full` option otherwise a mix of nil and non-nil values would fail the constraint and prevent the deletion of the referenced row.
+In addition, keep into consideration that this option is only supported from Postgres v15.0 onwards.
+
+## On Update
+
+This option describes what to do if the referenced row is updated.
+
+The possible values for the option are `:nothing`, `:restrict`, `:update`, `:nilify`.
+
+With `:nothing` or `:restrict` the update of the referenced row is prevented.
+
+With `:update` the row is updated according to the referenced row.
+
+With `:nilify` all columns of the foreign-key constraint are nilified.
+
 ## Nothing vs Restrict
 
 ```elixir
@@ -24,8 +54,4 @@ references do
 end
 ```
 
-The difference between `:nothing` and `:restrict` is subtle and, if you are unsure, choose `:nothing` (the default behavior). `:restrict` will prevent the deletion from happening _before_ the end of the database transaction, whereas `:nothing` allows the transaction to complete before doing so. This allows for things like updating or deleting the destination row and _then_ updating updating or deleting the reference(as long as you are in a transaction). The reason that `:nothing` still ultimately prevents deletion is because postgres enforces foreign key referential integrity.
-
-## On Delete
-
-This option is called `on_delete`, instead of `on_destroy`, because it is hooking into the database level deletion, _not_ a `destroy` action in your resource. See the warning above.
+The difference between `:nothing` and `:restrict` is subtle and, if you are unsure, choose `:nothing` (the default behavior). `:restrict` will immediately check the foreign-key constraint and prevent the update or deletion from happening, whereas `:nothing` allows the check to be deferred until later in the transaction. This allows for things like updating or deleting the destination row and _then_ updating updating or deleting the reference (as long as you are in a transaction). The reason that `:nothing` still ultimately prevents the update or deletion is because postgres enforces foreign key referential integrity.

--- a/lib/data_layer.ex
+++ b/lib/data_layer.ex
@@ -154,7 +154,12 @@ defmodule AshPostgres.DataLayer do
     entities: [@reference],
     schema: [
       polymorphic_on_delete: [
-        type: {:one_of, [:delete, :nilify, :nothing, :restrict]},
+        type:
+          {:or,
+           [
+             {:one_of, [:delete, :nilify, :nothing, :restrict]},
+             {:tagged_tuple, :nilify, {:wrap_list, :atom}}
+           ]},
         doc:
           "For polymorphic resources, configures the on_delete behavior of the automatically generated foreign keys to source tables."
       ],
@@ -227,7 +232,12 @@ defmodule AshPostgres.DataLayer do
     entities: [@reference],
     schema: [
       polymorphic_on_delete: [
-        type: {:one_of, [:delete, :nilify, :nothing, :restrict]},
+        type:
+          {:or,
+           [
+             {:one_of, [:delete, :nilify, :nothing, :restrict]},
+             {:tagged_tuple, :nilify, {:wrap_list, :atom}}
+           ]},
         doc:
           "For polymorphic resources, configures the on_delete behavior of the automatically generated foreign keys to source tables."
       ],

--- a/lib/migration_generator/operation.ex
+++ b/lib/migration_generator/operation.ex
@@ -42,6 +42,10 @@ defmodule AshPostgres.MigrationGenerator.Operation do
       end
     end
 
+    def on_delete(%{on_delete: {:nilify, columns}}) when is_list(columns) do
+      "on_delete: {:nilify, #{inspect(columns)}}"
+    end
+
     def on_delete(%{on_delete: on_delete}) when on_delete in [:delete, :nilify] do
       "on_delete: :#{on_delete}_all"
     end

--- a/lib/reference.ex
+++ b/lib/reference.ex
@@ -24,7 +24,12 @@ defmodule AshPostgres.Reference do
           "If set to true, no reference is created for the given relationship. This is useful if you need to define it in some custom way"
       ],
       on_delete: [
-        type: {:one_of, [:delete, :nilify, :nothing, :restrict]},
+        type:
+          {:or,
+           [
+             {:one_of, [:delete, :nilify, :nothing, :restrict]},
+             {:tagged_tuple, :nilify, {:wrap_list, :atom}}
+           ]},
         doc: """
         What should happen to records of this resource when the referenced record of the *destination* resource is deleted.
         """


### PR DESCRIPTION
Introduce the possibility to specify which columns of a foreign key should be set to NULL when the referenced resource is deleted: `on_delete: {:nilify, columns}`.
This provides more fine-grained control over the `on_delete: :nilify`  option for configuring the foreign key constraint, where the default behavior is to set all columns of the foreign key to `NULL`.

This is useful for example in cases where multitenancy is employed on resources, and a resource A has a `(tenant_id, resource_b_id)` foreign key that references the `tenant_id` and `id` columns of resource B: when the resource B is deleted, we'd like to nilify only the `resource_b_id` column of resource A and not its `tenant_id`.

Note: this functionality is supported by Ecto's `on_delete: {:nilify, columns}` option and ultimately by Postgres, although only from v15.0 onwards.

For details see:
- https://www.postgresql.org/docs/current/ddl-constraints.html#DDL-CONSTRAINTS-FK
- https://hexdocs.pm/ecto_sql/Ecto.Migration.html#references/2-options

### Contributor checklist

- [ ] Bug fixes include regression tests
- [x] Features include unit/acceptance tests
