### PR TITLE
test: add failing test to demonstrate an error with nested aggregates

### DIFF
--- a/test/complex_calculations_test.exs
+++ b/test/complex_calculations_test.exs
@@ -62,6 +62,30 @@ defmodule AshPostgres.Test.ComplexCalculationsTest do
     assert certification.some_documentation_created
   end
 
+  test "complex aggregates" do
+    certification =
+      AshPostgres.Test.ComplexCalculations.Certification
+      |> Ash.Changeset.new()
+      |> Ash.create!()
+
+    skill =
+      AshPostgres.Test.ComplexCalculations.Skill
+      |> Ash.Changeset.new()
+      |> Ash.Changeset.manage_relationship(:certification, certification, type: :append)
+      |> Ash.create!()
+
+    AshPostgres.Test.ComplexCalculations.Documentation
+    |> Ash.Changeset.for_create(:create, %{status: :demonstrated})
+    |> Ash.Changeset.manage_relationship(:skill, skill, type: :append)
+    |> Ash.create!()
+
+    certification =
+      certification
+      |> Ash.load!([:count_of_skills_ever_demonstrated])
+
+    assert certification.count_of_skills_ever_demonstrated == 1
+  end
+
   test "channel: first_member and second member" do
     channel =
       AshPostgres.Test.ComplexCalculations.Channel

--- a/test/support/complex_calculations/resources/certification.ex
+++ b/test/support/complex_calculations/resources/certification.ex
@@ -21,6 +21,13 @@ defmodule AshPostgres.Test.ComplexCalculations.Certification do
     count :count_of_skills, :skills do
       filter(expr(removed == false))
     end
+
+    sum :count_of_skills_ever_demonstrated,
+        :skills,
+        :count_ever_demonstrated do
+      filter(expr(removed == false))
+      public?(true)
+    end
   end
 
   attributes do

--- a/test/support/complex_calculations/resources/skill.ex
+++ b/test/support/complex_calculations/resources/skill.ex
@@ -14,6 +14,11 @@ defmodule AshPostgres.Test.ComplexCalculations.Skill do
     first :latest_documentation_status, [:documentations], :status do
       sort(timestamp: :desc)
     end
+
+    count :count_of_demonstrated_documentations, :documentations do
+      filter(expr(status == :demonstrated))
+      public?(true)
+    end
   end
 
   attributes do
@@ -32,6 +37,21 @@ defmodule AshPostgres.Test.ComplexCalculations.Skill do
           end
         )
       )
+    end
+
+    calculate :count_ever_demonstrated, :integer do
+      calculation(
+        expr(
+          if count_of_demonstrated_documentations == 0 do
+            0
+          else
+            1
+          end
+        )
+      )
+
+      load([:count_of_demonstrated_documentations])
+      public?(true)
     end
   end
 


### PR DESCRIPTION
The test produces the following:

```elixir
  1) test complex aggregates (AshPostgres.Test.ComplexCalculationsTest)
     test/complex_calculations_test.exs:66

     ** (Ash.Error.Unknown) Unknown Error
     * ** (Ecto.SubQueryError) the following exception happened when compiling a subquery.
         ** (Ecto.SubQueryError) the following exception happened when compiling a subquery.
             ** (Ecto.QueryError) could not find named binding `parent_as(false)` in query:

             from c0 in AshPostgres.Test.ComplexCalculations.Certification,
               as: 0,
               left_lateral_join: s1 in subquery(from s0 in AshPostgres.Test.ComplexCalculations.Skill,
               as: 0,
               left_lateral_join: d1 in subquery(from d0 in AshPostgres.Test.ComplexCalculations.Documentation,
               as: 0,
               where: parent_as(false).id == as(0).skill_id,
               where: type(
               as(0).status,
               {:parameterized, Ash.Type.Atom.EctoType,
                one_of: [:demonstrated, :performed, :approved, :reopened]}
             ) ==
               type(
                 ^"demonstrated",
                 {:parameterized, Ash.Type.Atom.EctoType,
                  one_of: [:demonstrated, :performed, :approved, :reopened]}
               ),
               group_by: [d0.skill_id],
               select: %{
               skill_id: map(d0, [:skill_id]).skill_id,
               count_of_demonstrated_documentations:
                 type(
                   coalesce(
                     count(type(as(0).id, {:parameterized, Ash.Type.UUID.EctoType, []})),
                     type(^0, {:parameterized, Ash.Type.Integer.EctoType, []})
                   ),
                   {:parameterized, Ash.Type.Integer.EctoType, []}
                 )
             }),
               on: true,
               where: parent_as(0).id == as(0).certification_id,
               where: type(as(0).removed, {:parameterized, Ash.Type.Boolean.EctoType, []}) ==
               type(^false, {:parameterized, Ash.Type.Boolean.EctoType, []}),
               group_by: [s0.certification_id],
               select: %{
               certification_id: map(s0, [:certification_id]).certification_id,
               count_of_skills_ever_demonstrated:
                 type(
                   sum(
                     type(
                       fragment(
                         "(CASE WHEN ? THEN ? ELSE ? END)",
                         type(
                           coalesce(
                             as(1).count_of_demonstrated_documentations,
                             type(^0, {:parameterized, Ash.Type.Integer.EctoType, []})
                           ),
                           {:parameterized, Ash.Type.Integer.EctoType, []}
                         ) == type(^0, {:parameterized, Ash.Type.Integer.EctoType, []}),
                         type(^0, {:parameterized, Ash.Type.Integer.EctoType, []}),
                         type(^1, {:parameterized, Ash.Type.Integer.EctoType, []})
                       ),
                       {:parameterized, Ash.Type.Integer.EctoType, []}
                     )
                   ),
                   {:parameterized, Ash.Type.Integer.EctoType, []}
                 )
             }),
               on: true,
               where: type(as(0).id, {:parameterized, Ash.Type.UUID.EctoType, []}) ==
               type(^"e24ef8a5-d39d-4293-9f69-1abd10a996e6", {:parameterized, Ash.Type.UUID.EctoType, []}),
               select: merge(
               merge(struct(c0, [:id]), %{
                 count_of_skills_ever_demonstrated:
                   type(
                     type(
                       s1.count_of_skills_ever_demonstrated,
                       {:parameterized, Ash.Type.Integer.EctoType, []}
                     ),
                     {:parameterized, Ash.Type.Integer.EctoType, []}
                   )
               }),
               %{}
             )

         The subquery originated from the following query:

         from s0 in AshPostgres.Test.ComplexCalculations.Skill,
           as: 0,
           left_lateral_join: d1 in subquery(from d0 in AshPostgres.Test.ComplexCalculations.Documentation,
           as: 0,
           where: parent_as(false).id == as(0).skill_id,
           where: type(
           as(0).status,
           {:parameterized, Ash.Type.Atom.EctoType,
            one_of: [:demonstrated, :performed, :approved, :reopened]}
         ) ==
           type(
             ^"demonstrated",
             {:parameterized, Ash.Type.Atom.EctoType,
              one_of: [:demonstrated, :performed, :approved, :reopened]}
           ),
           group_by: [d0.skill_id],
           select: %{
           skill_id: map(d0, [:skill_id]).skill_id,
           count_of_demonstrated_documentations:
             type(
               coalesce(
                 count(type(as(0).id, {:parameterized, Ash.Type.UUID.EctoType, []})),
                 type(^0, {:parameterized, Ash.Type.Integer.EctoType, []})
               ),
               {:parameterized, Ash.Type.Integer.EctoType, []}
             )
         }),
           on: true,
           where: parent_as(0).id == as(0).certification_id,
           where: type(as(0).removed, {:parameterized, Ash.Type.Boolean.EctoType, []}) ==
           type(^false, {:parameterized, Ash.Type.Boolean.EctoType, []}),
           group_by: [s0.certification_id],
           select: %{
           certification_id: map(s0, [:certification_id]).certification_id,
           count_of_skills_ever_demonstrated:
             type(
               sum(
                 type(
                   fragment(
                     "(CASE WHEN ? THEN ? ELSE ? END)",
                     type(
                       coalesce(
                         d1.count_of_demonstrated_documentations,
                         type(^..., {:parameterized, Ash.Type.Integer.EctoType, []})
                       ),
                       {:parameterized, Ash.Type.Integer.EctoType, []}
                     ) == type(^..., {:parameterized, Ash.Type.Integer.EctoType, []}),
                     type(^..., {:parameterized, Ash.Type.Integer.EctoType, []}),
                     type(^..., {:parameterized, Ash.Type.Integer.EctoType, []})
                   ),
                   {:parameterized, Ash.Type.Integer.EctoType, []}
                 )
               ),
               {:parameterized, Ash.Type.Integer.EctoType, []}
             )
         }

     The subquery originated from the following query:

     from c0 in AshPostgres.Test.ComplexCalculations.Certification,
       as: 0,
       left_lateral_join: s1 in subquery(from s0 in AshPostgres.Test.ComplexCalculations.Skill,
       as: 0,
       left_lateral_join: d1 in subquery(from d0 in AshPostgres.Test.ComplexCalculations.Documentation,
       as: 0,
       where: parent_as(false).id == as(0).skill_id,
       where: type(
       as(0).status,
       {:parameterized, Ash.Type.Atom.EctoType,
        one_of: [:demonstrated, :performed, :approved, :reopened]}
     ) ==
       type(
         ^"demonstrated",
         {:parameterized, Ash.Type.Atom.EctoType,
          one_of: [:demonstrated, :performed, :approved, :reopened]}
       ),
       group_by: [d0.skill_id],
       select: %{
       skill_id: map(d0, [:skill_id]).skill_id,
       count_of_demonstrated_documentations:
         type(
           coalesce(
             count(type(as(0).id, {:parameterized, Ash.Type.UUID.EctoType, []})),
             type(^0, {:parameterized, Ash.Type.Integer.EctoType, []})
           ),
           {:parameterized, Ash.Type.Integer.EctoType, []}
         )
     }),
       on: true,
       where: parent_as(0).id == as(0).certification_id,
       where: type(as(0).removed, {:parameterized, Ash.Type.Boolean.EctoType, []}) ==
       type(^false, {:parameterized, Ash.Type.Boolean.EctoType, []}),
       group_by: [s0.certification_id],
       select: %{
       certification_id: map(s0, [:certification_id]).certification_id,
       count_of_skills_ever_demonstrated:
         type(
           sum(
             type(
               fragment(
                 "(CASE WHEN ? THEN ? ELSE ? END)",
                 type(
                   coalesce(
                     as(1).count_of_demonstrated_documentations,
                     type(^0, {:parameterized, Ash.Type.Integer.EctoType, []})
                   ),
                   {:parameterized, Ash.Type.Integer.EctoType, []}
                 ) == type(^0, {:parameterized, Ash.Type.Integer.EctoType, []}),
                 type(^0, {:parameterized, Ash.Type.Integer.EctoType, []}),
                 type(^1, {:parameterized, Ash.Type.Integer.EctoType, []})
               ),
               {:parameterized, Ash.Type.Integer.EctoType, []}
             )
           ),
           {:parameterized, Ash.Type.Integer.EctoType, []}
         )
     }),
       on: true,
       where: type(as(0).id, {:parameterized, Ash.Type.UUID.EctoType, []}) ==
       type(^"e24ef8a5-d39d-4293-9f69-1abd10a996e6", {:parameterized, Ash.Type.UUID.EctoType, []}),
       select: merge(
       merge(struct(c0, [:id]), %{
         count_of_skills_ever_demonstrated:
           type(
             type(
               s1.count_of_skills_ever_demonstrated,
               {:parameterized, Ash.Type.Integer.EctoType, []}
             ),
             {:parameterized, Ash.Type.Integer.EctoType, []}
           )
       }),
       %{}
     )

       (elixir 1.16.2) lib/enum.ex:1826: Enum."-map_reduce/3-lists^mapfoldl/2-0-"/3
       (elixir 1.16.2) lib/enum.ex:2528: Enum."-reduce/3-lists^foldl/2-0-"/3
       (ecto 3.11.2) lib/ecto/repo/queryable.ex:214: Ecto.Repo.Queryable.execute/4
       (ecto 3.11.2) lib/ecto/repo/queryable.ex:19: Ecto.Repo.Queryable.all/3
       (ash_postgres 2.0.2) lib/data_layer.ex:706: anonymous fn/3 in AshPostgres.DataLayer.run_query/2
       (ash_postgres 2.0.2) lib/data_layer.ex:704: AshPostgres.DataLayer.run_query/2
       (ash 3.0.2) lib/ash/actions/read/read.ex:2259: Ash.Actions.Read.run_query/4
       (ash 3.0.2) lib/ash/actions/read/read.ex:903: Ash.Actions.Read.reselect_and_load/5
       (ash 3.0.2) lib/ash/actions/read/read.ex:244: Ash.Actions.Read.do_run/3
       (ash 3.0.2) lib/ash/actions/read/read.ex:66: anonymous fn/3 in Ash.Actions.Read.run/3
       (ash 3.0.2) lib/ash/actions/read/read.ex:65: Ash.Actions.Read.run/3
       (ash 3.0.2) lib/ash.ex:1717: Ash.load/3
       (ash 3.0.2) lib/ash.ex:1687: Ash.load/3
       (ash 3.0.2) lib/ash.ex:1635: Ash.load!/3
       test/complex_calculations_test.exs:85: AshPostgres.Test.ComplexCalculationsTest."test complex aggregates"/1
       (ex_unit 1.16.2) lib/ex_unit/runner.ex:472: ExUnit.Runner.exec_test/2
       (stdlib 5.2) timer.erl:270: :timer.tc/2
       (ex_unit 1.16.2) lib/ex_unit/runner.ex:394: anonymous fn/6 in ExUnit.Runner.spawn_test_monitor/4
     code: |> Ash.load!([:count_of_skills_ever_demonstrated])
     stacktrace:
       (elixir 1.16.2) lib/process.ex:860: Process.info/2
       (ash 3.0.2) lib/ash/error/unknown.ex:3: Ash.Error.Unknown."exception (overridable 2)"/1
       (ash 3.0.2) ash_postgres/deps/splode/lib/splode.ex:211: Ash.Error.to_class/2
       (ash 3.0.2) lib/ash/error/error.ex:66: Ash.Error.to_error_class/2
       (ash 3.0.2) lib/ash/actions/read/read.ex:324: Ash.Actions.Read.do_run/3
       (ash 3.0.2) lib/ash/actions/read/read.ex:66: anonymous fn/3 in Ash.Actions.Read.run/3
       (ash 3.0.2) lib/ash/actions/read/read.ex:65: Ash.Actions.Read.run/3
       (ash 3.0.2) lib/ash.ex:1717: Ash.load/3
       (ash 3.0.2) lib/ash.ex:1687: Ash.load/3
       (ash 3.0.2) lib/ash.ex:1635: Ash.load!/3
       test/complex_calculations_test.exs:85: (test)
```