### PR TITLE
improvement: add `ash_postgres.squash_snapshots` mix task

### DIFF
--- a/lib/migration_generator/migration_generator.ex
+++ b/lib/migration_generator/migration_generator.ex
@@ -2322,26 +2322,14 @@ defmodule AshPostgres.MigrationGenerator do
     if File.exists?(snapshot_folder) do
       snapshot_folder
       |> File.ls!()
-      |> Enum.filter(&String.ends_with?(&1, ".json"))
-      |> Enum.map(&String.trim_trailing(&1, ".json"))
-      |> Enum.map(&Integer.parse/1)
-      |> Enum.filter(fn
-        {_int, remaining} ->
-          remaining == ""
-
-        :error ->
-          false
-      end)
-      |> Enum.map(&elem(&1, 0))
+      |> Enum.filter(&String.match?(&1, ~r/^\d{14}\.json$/))
       |> case do
         [] ->
           get_old_snapshot(folder, snapshot)
 
-        timestamps ->
-          timestamp = Enum.max(timestamps)
-          snapshot_file = Path.join(snapshot_folder, "#{timestamp}.json")
-
-          snapshot_file
+        snapshot_files ->
+          snapshot_folder
+          |> Path.join(Enum.max(snapshot_files))
           |> File.read!()
           |> load_snapshot()
       end

--- a/lib/mix/tasks/ash_postgres.squash_snapshots.ex
+++ b/lib/mix/tasks/ash_postgres.squash_snapshots.ex
@@ -1,0 +1,117 @@
+defmodule Mix.Tasks.AshPostgres.SquashSnapshots do
+  use Mix.Task
+
+  @shortdoc "Cleans snapshots folder, leaving only one snapshot per resource"
+
+  @switches [
+    into: :string,
+    snapshot_path: :string,
+    quiet: :boolean,
+    dry_run: :boolean,
+    check: :boolean
+  ]
+
+  @moduledoc """
+  Cleans snapshots folder, leaving only one snapshot per resource.
+
+  ## Examples
+
+      mix ash_postgres.squash_snapshots
+      mix ash_postgres.squash_snapshots --check --quiet
+      mix ash_postgres.squash_snapshots --into zero
+      mix ash_postgres.squash_snapshots --dry-run
+
+  ## Command line options
+
+  * `--into` -
+      `last`, `first` or `zero`. The default is `last`. Determines which name to use for
+      a remaining snapshot. `last` keeps the name of the last snapshot, `first` renames it to the previously first,
+      `zero` sets name with fourteen zeros.
+  * `--snapshot-path` - a custom path to stored snapshots. The default is "priv/resource_snapshots".
+  * `--quiet` - no messages will not be printed.
+  * `--dry-run` - no files are touched, instead prints folders that have snapshots to squash.
+  * `--check` - no files are touched, instead returns an exit(1) code if there are snapshots to squash.
+  """
+
+  def run(args) do
+    {opts, []} = OptionParser.parse!(args, strict: @switches)
+
+    opts =
+      opts
+      |> Map.new()
+      |> Map.put_new(:into, "last")
+      |> Map.put_new(:snapshot_path, "priv/resource_snapshots")
+      |> Map.put_new(:quiet, false)
+      |> Map.put_new(:dry_run, false)
+      |> Map.put_new(:check, false)
+      |> Map.update!(:into, fn
+        "last" -> :last
+        "first" -> :first
+        "zero" -> :zero
+        _other -> raise "Valid values for --into flag are `last`, `first` and `zero`."
+      end)
+
+    squashable =
+      opts.snapshot_path
+      |> Path.join("**/*.json")
+      |> Path.wildcard()
+      |> Enum.filter(&String.match?(Path.basename(&1), ~r/^\d{14}\.json$/))
+      |> Enum.group_by(&Path.dirname(&1))
+      |> Enum.reduce([], fn {folder, snapshots}, squashable ->
+        last_snapshot = Enum.max(snapshots)
+
+        into_snapshot =
+          case opts.into do
+            :last -> last_snapshot
+            :first -> Enum.min(snapshots)
+            :zero -> Path.join(folder, "00000000000000.json")
+          end
+
+        if length(snapshots) > 1 or last_snapshot != into_snapshot do
+          [{folder, snapshots, last_snapshot, into_snapshot} | squashable]
+        else
+          squashable
+        end
+      end)
+      |> Enum.reverse()
+
+    if Enum.empty?(squashable) do
+      print(opts, "No snapshots to squash.")
+    else
+      if opts.dry_run do
+        print(opts, "Snapshots in following folders would have been squashed in non-dry run:")
+        print(opts, Enum.map_join(squashable, "\n", fn {folder, _, _, _} -> folder end))
+
+        if opts.check do
+          exit({:shutdown, 1})
+        end
+      end
+
+      if opts.check do
+        print(opts, """
+        Snapshots would have been squashed, but the --check flag was provided.
+
+        To see what snapshots would have been squashed, run with the --dry-run
+        flag. To squash those snapshots, run without either flag.
+        """)
+
+        exit({:shutdown, 1})
+      end
+
+      if not opts.dry_run do
+        for {_folder, snapshots, last_snapshot, into_snapshot} <- squashable do
+          for snapshot <- snapshots, snapshot != last_snapshot do
+            File.rm!(snapshot)
+          end
+
+          if last_snapshot != into_snapshot do
+            File.rename!(last_snapshot, into_snapshot)
+          end
+        end
+      end
+    end
+  end
+
+  defp print(%{quiet: true}, _message), do: nil
+  defp print(_opts, message), do: Mix.shell().info(message)
+end

--- a/test/mix_squash_snapshots_test.exs
+++ b/test/mix_squash_snapshots_test.exs
@@ -1,0 +1,205 @@
+defmodule AshPostgres.MixSquashSnapshotsTest do
+  use AshPostgres.RepoCase, async: false
+
+  defmacrop defposts(mod \\ Post, do: body) do
+    quote do
+      Code.compiler_options(ignore_module_conflict: true)
+
+      defmodule unquote(mod) do
+        use Ash.Resource,
+          domain: nil,
+          data_layer: AshPostgres.DataLayer
+
+        postgres do
+          table "posts"
+          repo(AshPostgres.TestRepo)
+
+          custom_indexes do
+            # need one without any opts
+            index(["id"])
+            index(["id"], unique: true, name: "test_unique_index")
+          end
+        end
+
+        actions do
+          defaults([:create, :read, :update, :destroy])
+        end
+
+        unquote(body)
+      end
+
+      Code.compiler_options(ignore_module_conflict: false)
+    end
+  end
+
+  defmacrop defdomain(resources) do
+    quote do
+      Code.compiler_options(ignore_module_conflict: true)
+
+      defmodule Domain do
+        use Ash.Domain
+
+        resources do
+          for resource <- unquote(resources) do
+            resource(resource)
+          end
+        end
+      end
+
+      Code.compiler_options(ignore_module_conflict: false)
+    end
+  end
+
+  def squash_snapshots(args) do
+    args = ["--snapshot-path", "test_snapshots_path"] ++ args
+    Mix.Task.rerun("ash_postgres.squash_snapshots", args)
+  end
+
+  def list_snapshots do
+    Path.wildcard("test_snapshots_path/**/[0-9]*.json")
+  end
+
+  describe "with two snapshots to squash" do
+    setup do
+      on_exit(fn ->
+        File.rm_rf!("test_snapshots_path")
+        File.rm_rf!("test_migration_path")
+      end)
+
+      Mix.shell(Mix.Shell.Process)
+
+      defposts do
+        identities do
+          identity(:title, [:title])
+        end
+
+        attributes do
+          uuid_primary_key(:id)
+          attribute(:title, :string, public?: true)
+        end
+      end
+
+      defdomain([Post])
+
+      AshPostgres.MigrationGenerator.generate(Domain,
+        snapshot_path: "test_snapshots_path",
+        migration_path: "test_migration_path",
+        quiet: true,
+        format: false
+      )
+
+      defposts do
+        identities do
+          identity(:title, [:title])
+        end
+
+        attributes do
+          uuid_primary_key(:id)
+          attribute(:title, :string, public?: true)
+          attribute(:name, :string, allow_nil?: false, public?: true)
+        end
+      end
+
+      AshPostgres.MigrationGenerator.generate(Domain,
+        snapshot_path: "test_snapshots_path",
+        migration_path: "test_migration_path",
+        quiet: true,
+        format: false
+      )
+
+      :ok
+    end
+
+    test "runs without flags" do
+      [_first_snapshot, last_snapshot] = list_snapshots() |> Enum.sort()
+      squash_snapshots([])
+      assert [^last_snapshot] = list_snapshots()
+    end
+
+    test "runs with `--check`" do
+      prev_snapshots = list_snapshots()
+      assert catch_exit(squash_snapshots(["--check"])) == {:shutdown, 1}
+      assert prev_snapshots == list_snapshots()
+    end
+
+    test "runs with `--dry-run`" do
+      prev_snapshots = list_snapshots()
+      squash_snapshots(["--dry-run"])
+      assert prev_snapshots == list_snapshots()
+    end
+
+    test "runs with `--into last`" do
+      [_first_snapshot, last_snapshot] = list_snapshots() |> Enum.sort()
+      squash_snapshots(["--into", "last"])
+      assert [^last_snapshot] = list_snapshots()
+    end
+
+    test "runs with `--into first`" do
+      [first_snapshot, _last_snapshot] = list_snapshots() |> Enum.sort()
+      squash_snapshots(["--into", "first"])
+      assert [^first_snapshot] = list_snapshots()
+    end
+
+    test "runs with `--into zero`" do
+      squash_snapshots(["--into", "zero"])
+      assert ["test_snapshots_path/test_repo/posts/00000000000000.json"] = list_snapshots()
+    end
+  end
+
+  describe "with one snapshot to squash" do
+    setup do
+      on_exit(fn ->
+        File.rm_rf!("test_snapshots_path")
+        File.rm_rf!("test_migration_path")
+      end)
+
+      Mix.shell(Mix.Shell.Process)
+
+      defposts do
+        identities do
+          identity(:title, [:title])
+        end
+
+        attributes do
+          uuid_primary_key(:id)
+          attribute(:title, :string, public?: true)
+        end
+      end
+
+      defdomain([Post])
+
+      AshPostgres.MigrationGenerator.generate(Domain,
+        snapshot_path: "test_snapshots_path",
+        migration_path: "test_migration_path",
+        quiet: true,
+        format: false
+      )
+
+      :ok
+    end
+
+    test "runs with `--check`" do
+      prev_snapshots = list_snapshots()
+      squash_snapshots(["--check"])
+      assert prev_snapshots == list_snapshots()
+    end
+
+    test "runs with `--check --into last`" do
+      prev_snapshots = list_snapshots()
+      squash_snapshots(["--check", "--into", "last"])
+      assert prev_snapshots == list_snapshots()
+    end
+
+    test "runs with `--check --into first`" do
+      prev_snapshots = list_snapshots()
+      squash_snapshots(["--check", "--into", "last"])
+      assert prev_snapshots == list_snapshots()
+    end
+
+    test "runs with `--check --into zero`" do
+      prev_snapshots = list_snapshots()
+      assert catch_exit(squash_snapshots(["--check", "--into", "zero"])) == {:shutdown, 1}
+      assert prev_snapshots == list_snapshots()
+    end
+  end
+end


### PR DESCRIPTION
Implements  #301.

Note: I put `--into last` as default behavior. So by default it just removes old snapshots leaving one. Which is not helpful for multi-branch thing, but, I guess, makes sense in terms of cleaning up.