### PR TITLE
fix: configure_runtime/3 in ash_postgres.install

### DIFF
--- a/lib/mix/tasks/ash_postgres.install.ex
+++ b/lib/mix/tasks/ash_postgres.install.ex
@@ -14,7 +14,7 @@ defmodule Mix.Tasks.AshPostgres.Install do
     |> configure_config(otp_app, repo)
     |> configure_dev(otp_app, repo)
     |> configure_test(otp_app, repo)
-    |> configure_runtime(repo, otp_app)
+    |> configure_runtime(otp_app, repo)
     |> Igniter.Project.Application.add_new_child(repo)
     |> Igniter.add_task("ash.codegen", ["install_ash_postgres"])
   end
@@ -47,7 +47,7 @@ defmodule Mix.Tasks.AshPostgres.Install do
           For example: ecto://USER:PASS@HOST/DATABASE
           \"\"\"
 
-      config #{inspect(otp_app)}, Helpdesk.Repo,
+      config #{inspect(otp_app)}, #{inspect(repo),
         url: database_url,
         pool_size: String.to_integer(System.get_env("POOL_SIZE") || "10")
     end


### PR DESCRIPTION
### Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests

This PR fixes an ordering typo when passing arguments to `configure_runtime` as well as changes the placeholder for `Helpdesk.Repo` to be the repo argument.