### PR TITLE
fix: typo in configure_runtime/3

### DIFF
--- a/lib/mix/tasks/ash_postgres.install.ex
+++ b/lib/mix/tasks/ash_postgres.install.ex
@@ -47,7 +47,7 @@ defmodule Mix.Tasks.AshPostgres.Install do
           For example: ecto://USER:PASS@HOST/DATABASE
           \"\"\"
 
-      config #{inspect(otp_app)}, #{inspect(repo),
+      config #{inspect(otp_app)}, #{inspect(repo)},
         url: database_url,
         pool_size: String.to_integer(System.get_env("POOL_SIZE") || "10")
     end


### PR DESCRIPTION
### Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests

It seems that my recent PR had a nasty little typo that actually broke the installer. Sorry about that :grimacing:. (I had it fixed locally but seems that I had forgotten to push the change to my fork.)