### PR TITLE
docs: Add note that `nulls_distinct` requires PostgreSQL 15

### DIFF
--- a/lib/custom_index.ex
+++ b/lib/custom_index.ex
@@ -62,7 +62,7 @@ defmodule AshPostgres.CustomIndex do
     ],
     nulls_distinct: [
       type: :boolean,
-      doc: "specify whether null values should be considered distinct for a unique index.",
+      doc: "specify whether null values should be considered distinct for a unique index. Requires PostgreSQL 15 or later",
       default: true
     ],
     message: [


### PR DESCRIPTION
Unfortunately it's not an option on indexes in PostgreSQL 14 :( 

https://www.postgresql.org/docs/14/sql-createindex.html

### Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests
