### PR TITLE
Cleanup Test Output

### DIFF
--- a/lib/migration_generator/migration_generator.ex
+++ b/lib/migration_generator/migration_generator.ex
@@ -379,7 +379,7 @@ defmodule AshPostgres.MigrationGenerator do
 
         operations ->
           if opts.check do
-            IO.puts("""
+            Mix.shell().error("""
             Migrations would have been generated, but the --check flag was provided.
 
             To see what migration would have been generated, run with the `--dry-run`
@@ -1028,7 +1028,7 @@ defmodule AshPostgres.MigrationGenerator do
     end
   rescue
     exception ->
-      IO.puts("""
+      Mix.shell().error("""
       Exception while formatting:
 
       #{inspect(exception)}

--- a/test/mix_squash_snapshots_test.exs
+++ b/test/mix_squash_snapshots_test.exs
@@ -2,6 +2,16 @@ defmodule AshPostgres.MixSquashSnapshotsTest do
   use AshPostgres.RepoCase, async: false
   @moduletag :migration
 
+  setup do
+    current_shell = Mix.shell()
+
+    :ok = Mix.shell(Mix.Shell.Process)
+
+    on_exit(fn ->
+      Mix.shell(current_shell)
+    end)
+  end
+
   defmacrop defposts(mod \\ Post, do: body) do
     quote do
       Code.compiler_options(ignore_module_conflict: true)
@@ -66,8 +76,6 @@ defmodule AshPostgres.MixSquashSnapshotsTest do
         File.rm_rf!("test_snapshots_path")
         File.rm_rf!("test_migration_path")
       end)
-
-      Mix.shell(Mix.Shell.Process)
 
       defposts do
         identities do
@@ -153,8 +161,6 @@ defmodule AshPostgres.MixSquashSnapshotsTest do
         File.rm_rf!("test_snapshots_path")
         File.rm_rf!("test_migration_path")
       end)
-
-      Mix.shell(Mix.Shell.Process)
 
       defposts do
         identities do


### PR DESCRIPTION
Cleans up mix task output and compiler warnings in tests.

**Changes**

I changed `IO.puts/1` to `Mix.shell().error/1` in the `MigrationGenerator`. Other places are using `Mix.shell().info/1` already.
This will change the color of the output.

### Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests
