### PR TITLE
Handle filter condition on create

### DIFF
--- a/test/bulk_create_test.exs
+++ b/test/bulk_create_test.exs
@@ -65,6 +65,50 @@ defmodule AshPostgres.BulkCreateTest do
                end)
     end
 
+    test "bulk upsert skips with filter" do
+      assert [
+               {:ok, %{title: "fredfoo", uniq_if_contains_foo: "1foo", price: 10}},
+               {:ok, %{title: "georgefoo", uniq_if_contains_foo: "2foo", price: 20}},
+               {:ok, %{title: "herbert", uniq_if_contains_foo: "3", price: 30}}
+             ] =
+               Ash.bulk_create!(
+                 [
+                   %{title: "fredfoo", uniq_if_contains_foo: "1foo", price: 10},
+                   %{title: "georgefoo", uniq_if_contains_foo: "2foo", price: 20},
+                   %{title: "herbert", uniq_if_contains_foo: "3", price: 30}
+                 ],
+                 Post,
+                 :create,
+                 return_stream?: true,
+                 return_records?: true
+               )
+               |> Enum.sort_by(fn {:ok, result} -> result.title end)
+
+      assert [
+               {:ok, %{title: "georgefoo", uniq_if_contains_foo: "2foo", price: 20_000}},
+               {:ok, %{title: "herbert", uniq_if_contains_foo: "3", price: 30}}
+             ] =
+               Ash.bulk_create!(
+                 [
+                   %{title: "fredfoo", uniq_if_contains_foo: "1foo", price: 10},
+                   %{title: "georgefoo", uniq_if_contains_foo: "2foo", price: 20_000},
+                   %{title: "herbert", uniq_if_contains_foo: "3", price: 30}
+                 ],
+                 Post,
+                 :upsert_with_filter,
+                 return_stream?: true,
+                 return_errors?: true,
+                 return_records?: true
+               )
+               |> Enum.sort_by(fn
+                 {:ok, result} ->
+                   result.title
+
+                 _ ->
+                   nil
+               end)
+    end
+
     # confirmed that this doesn't work because it can't. An upsert must map to a potentially successful insert.
     # leaving this test here for posterity
     # test "bulk creates can upsert with id" do

--- a/test/create_test.exs
+++ b/test/create_test.exs
@@ -1,0 +1,58 @@
+defmodule AshPostgres.CreateTest do
+  use AshPostgres.RepoCase, async: false
+  alias AshPostgres.Test.Post
+
+  test "creates insert" do
+    assert {:ok, %Post{}} =
+             Post
+             |> Ash.Changeset.for_create(:create, %{title: "fred"})
+             |> Ash.create()
+
+    assert [%{title: "fred"}] =
+             Post
+             |> Ash.Query.sort(:title)
+             |> Ash.read!()
+  end
+
+  test "upserts entry" do
+    assert {:ok, %Post{id: id}} =
+             Post
+             |> Ash.Changeset.for_create(:create, %{
+               title: "fredfoo",
+               uniq_if_contains_foo: "foo",
+               price: 10
+             })
+             |> Ash.create()
+
+    assert {:ok, %Post{id: ^id, price: 20}} =
+             Post
+             |> Ash.Changeset.for_create(:upsert_with_filter, %{
+               title: "fredfoo",
+               uniq_if_contains_foo: "foo",
+               price: 20
+             })
+             |> Ash.create()
+  end
+
+  test "skips upsert with filter" do
+    assert {:ok, %Post{id: id}} =
+             Post
+             |> Ash.Changeset.for_create(:create, %{
+               title: "fredfoo",
+               uniq_if_contains_foo: "foo",
+               price: 10
+             })
+             |> Ash.create()
+
+    assert {:ok, %Post{id: ^id} = post} =
+             Post
+             |> Ash.Changeset.for_create(:upsert_with_filter, %{
+               title: "fredfoo",
+               uniq_if_contains_foo: "foo",
+               price: 10
+             })
+             |> Ash.create()
+
+    assert Ash.Resource.get_metadata(post, :upsert_skipped)
+  end
+end

--- a/test/support/resources/post.ex
+++ b/test/support/resources/post.ex
@@ -258,6 +258,16 @@ defmodule AshPostgres.Test.Post do
       )
     end
 
+    create :upsert_with_filter do
+      upsert?(true)
+      upsert_identity(:uniq_if_contains_foo)
+      upsert_fields([:price])
+
+      change(fn changeset, _ ->
+        Ash.Changeset.filter(changeset, expr(price != fragment("EXCLUDED.price")))
+      end)
+    end
+
     update :set_title_from_author do
       change(atomic_update(:title, expr(author.first_name)))
     end
@@ -292,7 +302,7 @@ defmodule AshPostgres.Test.Post do
     identity(:uniq_on_upper, [:upper_thing])
 
     identity(:uniq_if_contains_foo, [:uniq_if_contains_foo]) do
-      where expr(contains(title, "foo"))
+      where expr(contains(uniq_if_contains_foo, "foo"))
     end
   end
 

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,4 +1,4 @@
-ExUnit.start()
+ExUnit.start(capture_log: true)
 ExUnit.configure(stacktrace_depth: 100)
 
 AshPostgres.TestRepo.start_link()


### PR DESCRIPTION
I implemented it so that the single create returns the existing row.

Any row that was skipped because of the upsert filter clause will have the metadata entry `upsert_skipped` set.

Alternatively we could return `nil`, but I believe that might confuse the users of the function. With bulk creates it makes more sense to be missing.

I couldn't find specific tests for single create / single bulk create. So I added those as well.

This is a prerequisite to implement the syntax sugar from https://github.com/ash-project/ash/issues/1385

### Contributor checklist

- [X] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests
