### PR TITLE
docs: Output valid example code in ValidateIdentityIndexNames

### DIFF
--- a/lib/verifiers/validate_identity_index_names.ex
+++ b/lib/verifiers/validate_identity_index_names.ex
@@ -49,7 +49,7 @@ defmodule AshPostgres.Verifiers.ValidateIdentityIndexNames do
               Please configure an index name for this identity in the `identity_index_names` configuration. For example:
 
               postgres do
-                identity_index_names #{inspect(identity.name)}: "a_shorter_name"
+                identity_index_names #{identity.name}: "a_shorter_name"
               end
               """
           end


### PR DESCRIPTION
`identity.name` is an atom and we don't want to include the `:` in the output in this case.

Before
```
postgres do
  identity_index_names :unique_id: "a_shorter_name"
end
```

After
```
postgres do
  identity_index_names unique_id: "a_shorter_name"
end
```

### Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests
