### PR TITLE
chore: fix PG_VERSION parsing in tests

### DIFF
--- a/test/support/test_repo.ex
+++ b/test/support/test_repo.ex
@@ -14,8 +14,14 @@ defmodule AshPostgres.TestRepo do
 
   def min_pg_version do
     case System.get_env("PG_VERSION") do
-      nil -> %Version{major: 16, minor: 0, patch: 0}
-      version -> Version.parse!(version)
+      nil ->
+        %Version{major: 16, minor: 0, patch: 0}
+
+      version ->
+        case Integer.parse(version) do
+          {major, ""} -> %Version{major: major, minor: 0, patch: 0}
+          _ -> Version.parse!(version)
+        end
     end
   end
 


### PR DESCRIPTION
Allow passing a bare integer as PG_VERSION, which will be interpreted as a major version

### Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests
