### PR TITLE
Fix links in documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Change Log
 
 All notable changes to this project will be documented in this file.
-See [Conventional Commits](Https://conventionalcommits.org) for commit guidelines.
+See [Conventional Commits](https://www.conventionalcommits.org) for commit guidelines.
 
 <!-- changelog -->
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -205,13 +205,13 @@ causing nontrivial performance issues at scale.
 
 - [`ash_postgres.gen.migration`] dynamically select and allow setting a repo
 
-## [v2.1.17](https://github.com/ash-project/ash_postgres/compare/v2.1.16...v2.1.17) (2024-07-27)
+## v2.1.17 (2024-07-27)
 
 ### Improvements:
 
 - [`ash_sql`] update ash & ash_sql for various fixes
 
-## [v2.1.16](https://github.com/ash-project/ash_postgres/compare/v2.1.15...v2.1.16) (2024-07-25)
+## v2.1.16 (2024-07-25)
 
 ### Bug Fixes:
 
@@ -273,7 +273,7 @@ causing nontrivial performance issues at scale.
 
 - [`mix ash.gen.resource`] pluralize table name in extender
 
-## [v2.1.8](https://github.com/ash-project/ash_postgres/compare/v2.1.7...v2.1.8) (2024-07-17)
+## v2.1.8 (2024-07-17)
 
 ### Bug Fixes:
 
@@ -287,7 +287,7 @@ causing nontrivial performance issues at scale.
 
 - [expressions] add `binding()` expression, for referring to the current table
 
-## [v2.1.7](https://github.com/ash-project/ash_postgres/compare/v2.1.6...v2.1.7) (2024-07-17)
+## v2.1.7 (2024-07-17)
 
 ### Bug Fixes:
 
@@ -351,13 +351,13 @@ causing nontrivial performance issues at scale.
 
 - [query builder] update ash & improve type casting behavior
 
-## [v2.1.1](https://github.com/ash-project/ash_postgres/compare/v2.1.0...v2.1.1) (2024-07-10)
+## v2.1.1 (2024-07-10)
 
 ### Bug Fixes:
 
 - [mix ash_postgres.install] properly interpolate module names in installer
 
-## [v2.1.0](https://github.com/ash-project/ash_postgres/compare/v2.0.12...v2.1.0) (2024-07-10)
+## v2.1.0 (2024-07-10)
 
 ### Features:
 
@@ -432,7 +432,7 @@ causing nontrivial performance issues at scale.
 
 ## [v2.0.8](https://github.com/ash-project/ash_postgres/compare/v2.0.7...v2.0.8) (2024-06-06)
 
-## [v2.0.7](https://github.com/ash-project/ash_postgres/compare/v2.0.6...v2.0.7) (2024-06-06)
+## v2.0.7 (2024-06-06)
 
 ### Bug Fixes:
 
@@ -440,7 +440,7 @@ causing nontrivial performance issues at scale.
 
 - [fix] ensure that all current attribute values are selected on bulk update shifted root query
 
-## [v2.0.6](https://github.com/ash-project/ash_postgres/compare/v2.0.5...v2.0.6) (2024-05-29)
+## v2.0.6 (2024-05-29)
 
 ### Bug Fixes:
 
@@ -458,7 +458,7 @@ causing nontrivial performance issues at scale.
 
 - [mix ash_postgres.squash_snapshots] add `ash_postgres.squash_snapshots` mix task (#302)
 
-## [v2.0.5](https://github.com/ash-project/ash_postgres/compare/v2.0.4...v2.0.5) (2024-05-24)
+## v2.0.5 (2024-05-24)
 
 ### Improvements:
 
@@ -498,13 +498,13 @@ causing nontrivial performance issues at scale.
 
 - [AshPostgres.MigrationGenerator] properly parse previous version from migration generation
 
-## [v2.0.1](https://github.com/ash-project/ash_postgres/compare/v2.0.0...v2.0.1) (2024-05-12)
+## v2.0.1 (2024-05-12)
 
 ### Bug Fixes:
 
 - [AshPostgres.MigrationGenerator] properly parse previous version of custom extensions when generating migrations
 
-## [v2.0.0](https://github.com/ash-project/ash_postgres/compare/v2.0.0...2.0)
+## v2.0.0
 
 The changelog is starting over. Please see `/documentation/1.0-CHANGELOG.md` in GitHub for previous changelogs.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 ![Logo](https://github.com/ash-project/ash/blob/main/logos/cropped-for-header-white-text.png?raw=true#gh-dark-mode-only)
 
 ![Elixir CI](https://github.com/ash-project/ash_postgres/workflows/CI/badge.svg)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/license/MIT)
 [![Hex version badge](https://img.shields.io/hexpm/v/ash_postgres.svg)](https://hex.pm/packages/ash_postgres)
 [![Hexdocs badge](https://img.shields.io/badge/docs-hexdocs-purple)](https://hexdocs.pm/ash_postgres)
 

--- a/documentation/topics/advanced/manual-relationships.md
+++ b/documentation/topics/advanced/manual-relationships.md
@@ -1,6 +1,6 @@
 # Manual Relationships
 
-See [Defining Manual Relationships](https://hexdocs.pm/ash/defining-manual-relationships.html) for an idea of manual relationships in general.
+See [Manual Relationships](https://hexdocs.pm/ash/relationships.html#manual-relationships) for an idea of manual relationships in general.
 Manual relationships allow for expressing complex/non-typical relationships between resources in a standard way.
 Individual data layers may interact with manual relationships in their own way, so see their corresponding guides.
 

--- a/documentation/tutorials/get-started-with-ash-postgres.md
+++ b/documentation/tutorials/get-started-with-ash-postgres.md
@@ -221,7 +221,7 @@ mix ash.setup
 
 ### Try it out
 
-This is based on the [Getting Started](https://hexdocs.pm/ash/getting_started.html) guide.
+This is based on the [Get Started](https://hexdocs.pm/ash/get-started.html) guide.
 If you haven't already, you should read that first.
 
 And now we're ready to try it out! Run the following in iex:

--- a/lib/functions/trigram_similarity.ex
+++ b/lib/functions/trigram_similarity.ex
@@ -2,7 +2,7 @@ defmodule AshPostgres.Functions.TrigramSimilarity do
   @moduledoc """
   Maps to the builtin postgres trigram similarity function. Requires `pgtrgm` extension to be installed.
 
-  See the postgres docs on [trigram](https://www.postgresql.org/docs/9.6/pgtrgm.html]) for more information.
+  See the postgres docs on [trigram](https://www.postgresql.org/docs/9.6/pgtrgm.html) for more information.
 
   Requires the pg_trgm extension. Configure which extensions you have installed in your `AshPostgres.Repo`
 


### PR DESCRIPTION
I'm new to Ash so I'm using documentation extensively. I've noticed links are sometimes leading nowhere.
So here's the fix for that.

### Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests
