### PR TITLE
improvement: add `postgres_reference_expr` callback to AshPostgres.Type

### DIFF
--- a/lib/sql_implementation.ex
+++ b/lib/sql_implementation.ex
@@ -154,6 +154,33 @@ defmodule AshPostgres.SqlImplementation do
   end
 
   def expr(
+    query,
+    %Ash.Query.Ref{
+      attribute: %Ash.Resource.Attribute{
+        type: attr_type,
+        constraints: constraints,
+      },
+      bare?: true
+    } = ref,
+    bindings,
+    embedded?,
+    acc,
+    type
+  ) do
+    if function_exported?(attr_type, :postgres_reference_expr, 3) do
+      non_bare_ref = %Ash.Query.Ref{ ref | bare?: nil }
+      {expr, acc} = AshSql.Expr.dynamic_expr(query, non_bare_ref, bindings, embedded?, type, acc)
+
+      case attr_type.postgres_reference_expr(attr_type, constraints, expr) do
+        {:ok, bare_expr} -> {:ok, bare_expr, acc}
+        :error -> :error
+      end
+    else
+      :error
+    end
+  end
+
+  def expr(
         _query,
         _expr,
         _bindings,

--- a/lib/type.ex
+++ b/lib/type.ex
@@ -8,12 +8,21 @@ defmodule AshPostgres.Type do
   @callback value_to_postgres_default(Ash.Type.t(), Ash.Type.constraints(), term) ::
               {:ok, String.t()} | :error
 
+  @callback postgres_reference_expr(Ash.Type.t(), Ash.Type.constraints(), term) ::
+              {:ok, term} | :error
+
+  @optional_callbacks value_to_postgres_default: 3,
+                      postgres_reference_expr: 3
+
   defmacro __using__(_) do
     quote do
       @behaviour AshPostgres.Type
-      def value_to_postgres_default(_, _, _), do: :error
 
-      defoverridable value_to_postgres_default: 3
+      def value_to_postgres_default(_, _, _), do: :error
+      def postgres_reference_expr(_, _, _), do: :error
+
+      defoverridable value_to_postgres_default: 3,
+                     postgres_reference_expr: 3
     end
   end
 end


### PR DESCRIPTION
We have a custom Ash type to help map integer columns in an existing database schema to booleans in Elixir. 

Ash.Type gets us most of the way there, but to support bare attribute filter expressions like `active?` we need to generate a boolean expression for the WHERE clause. This adds another callback to AshPostgres.Type so the implementation can rewrite those expressions when generating the query, eg. with a `? != 0` fragment for our integer-boolean example.

### Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests
