### PR TITLE
bug: add search path to postgres functions

### DIFF
--- a/lib/migration_generator/ash_functions.ex
+++ b/lib/migration_generator/ash_functions.ex
@@ -10,6 +10,7 @@ defmodule AshPostgres.MigrationGenerator.AshFunctions do
     CREATE OR REPLACE FUNCTION ash_elixir_or(left BOOLEAN, in right ANYCOMPATIBLE, out f1 ANYCOMPATIBLE)
     AS $$ SELECT COALESCE(NULLIF($1, FALSE), $2) $$
     LANGUAGE SQL
+    SET search_path = ''
     IMMUTABLE;
     \"\"\")
 
@@ -17,6 +18,7 @@ defmodule AshPostgres.MigrationGenerator.AshFunctions do
     CREATE OR REPLACE FUNCTION ash_elixir_or(left ANYCOMPATIBLE, in right ANYCOMPATIBLE, out f1 ANYCOMPATIBLE)
     AS $$ SELECT COALESCE($1, $2) $$
     LANGUAGE SQL
+    SET search_path = ''
     IMMUTABLE;
     \"\"\")
 
@@ -27,6 +29,7 @@ defmodule AshPostgres.MigrationGenerator.AshFunctions do
         ELSE $1
       END $$
     LANGUAGE SQL
+    SET search_path = ''
     IMMUTABLE;
     \"\"\")
 
@@ -37,6 +40,7 @@ defmodule AshPostgres.MigrationGenerator.AshFunctions do
         ELSE $1
       END $$
     LANGUAGE SQL
+    SET search_path = ''
     IMMUTABLE;
     \"\"\")
 
@@ -62,6 +66,7 @@ defmodule AshPostgres.MigrationGenerator.AshFunctions do
         END IF;
     END; $$
     LANGUAGE plpgsql
+    SET search_path = ''
     IMMUTABLE;
     \"\"\")
 
@@ -115,6 +120,7 @@ defmodule AshPostgres.MigrationGenerator.AshFunctions do
         END IF;
     END; $$
     LANGUAGE plpgsql
+    SET search_path = ''
     IMMUTABLE;
     \"\"\")
     """
@@ -177,7 +183,8 @@ defmodule AshPostgres.MigrationGenerator.AshFunctions do
         RAISE EXCEPTION '#{prefix}%', json_data::text;
         RETURN NULL;
     END;
-    $$ LANGUAGE plpgsql;
+    $$ LANGUAGE plpgsql
+    SET search_path = '';
     \"\"\")
 
     execute(\"\"\"
@@ -189,7 +196,8 @@ defmodule AshPostgres.MigrationGenerator.AshFunctions do
         RAISE EXCEPTION '#{prefix}%', json_data::text;
         RETURN NULL;
     END;
-    $$ LANGUAGE plpgsql;
+    $$ LANGUAGE plpgsql
+    SET search_path = '';
     \"\"\")
     """
   end
@@ -220,6 +228,7 @@ defmodule AshPostgres.MigrationGenerator.AshFunctions do
     END
     $$
     LANGUAGE PLPGSQL
+    SET search_path = ''
     VOLATILE;
     \"\"\")
 
@@ -230,6 +239,7 @@ defmodule AshPostgres.MigrationGenerator.AshFunctions do
       SELECT to_timestamp(('x0000' || substr(_uuid::TEXT, 1, 8) || substr(_uuid::TEXT, 10, 4))::BIT(64)::BIGINT::NUMERIC / 1000);
     $$
     LANGUAGE SQL
+    SET search_path = ''
     IMMUTABLE PARALLEL SAFE STRICT;
     \"\"\")
     """


### PR DESCRIPTION
This is a minor hardening of postgres security, in response to supabase advisor warnings.

It's only been added to the new migration generator, it's not serious enough to try and address elsewhere. This should mean that anyone setting up a new app will get these new settings.

Closes https://github.com/ash-project/ash_postgres/issues/396

@zachdaniel Sorry for the delay posting this! 

- I'm not sure how much further to test this. The changes have been applied to our app for a couple of months, no issues. 
- Tests pass (but I'd be surprised if there was coverage for this minor postgres setting)
- I created a new app, ran the generator and deployed to supabase: can confirm the warnings are gone

Before: 

![372654290-21878677-278a-4be3-b13b-08099406e81c](https://github.com/user-attachments/assets/45c5a137-b3bb-4dcf-b2b6-d9e8edc545ed)

After: 

![Screenshot 2024-12-24 at 23 16 46](https://github.com/user-attachments/assets/3a38303f-3061-42c5-9ab8-890e9dd727a3)

### Contributor checklist

- [ ] Bug fixes include regression tests (Not applicable)
- [ ] Features include unit/acceptance tests (Not applicable) 
