### PR TITLE
test: add test for relationship filter with `parent(parent(field))`

### DIFF
--- a/test/rel_with_parent_filter_test.exs
+++ b/test/rel_with_parent_filter_test.exs
@@ -1,7 +1,7 @@
 defmodule AshPostgres.RelWithParentFilterTest do
   use AshPostgres.RepoCase, async: false
 
-  alias AshPostgres.Test.Author
+  alias AshPostgres.Test.{Author, Comedian, Joke}
 
   require Ash.Query
 
@@ -74,5 +74,14 @@ defmodule AshPostgres.RelWithParentFilterTest do
              |> Ash.read_one!()
 
     assert length(authors) == 1
+  end
+
+  test "filter on relationship using double parent works as expected when loading relationship" do
+    commedian = Comedian.create!(%{name: "John"})
+    joke = Joke.create!(%{comedian_id: commedian.id})
+    joke_id = joke.id
+
+    commedian = Ash.load!(commedian, [:parent_parent_jokes])
+    assert [%{id: ^joke_id}] = commedian.parent_parent_jokes
   end
 end

--- a/test/support/resources/comedian.ex
+++ b/test/support/resources/comedian.ex
@@ -14,6 +14,10 @@ defmodule AshPostgres.Test.Comedian do
 
   relationships do
     has_many(:jokes, AshPostgres.Test.Joke, public?: true)
+
+    has_many :parent_parent_jokes, AshPostgres.Test.Joke do
+      filter expr(exists(comedian, id == parent(parent(id))))
+    end
   end
 
   calculations do

--- a/test/support/resources/joke.ex
+++ b/test/support/resources/joke.ex
@@ -19,6 +19,14 @@ defmodule AshPostgres.Test.Joke do
 
   actions do
     defaults([:read])
+
+    create :create do
+      accept [:text, :is_good, :comedian_id]
+    end
+  end
+
+  code_interface do
+    define(:create)
   end
 
   postgres do


### PR DESCRIPTION
The test currently fails.

`parent(parent(id))` behaves as `parent(id)`.
