### PR TITLE
Ignore module conflict when compiling migration file

### DIFF
--- a/lib/migration_compile_cache.ex
+++ b/lib/migration_compile_cache.ex
@@ -28,11 +28,14 @@ defmodule AshPostgres.MigrationCompileCache do
   defp ensure_compiled(state, file) do
     case Map.get(state, file) do
       nil ->
+        Code.put_compiler_option(:ignore_module_conflict, true)
         compiled = Code.compile_file(file)
         Map.put(state, file, compiled)
 
       _ ->
         state
     end
+  after
+    Code.put_compiler_option(:ignore_module_conflict, false)
   end
 end

--- a/lib/multitenancy.ex
+++ b/lib/multitenancy.ex
@@ -15,8 +15,6 @@ defmodule AshPostgres.MultiTenancy do
       migrations_path ||
         repo.config()[:tenant_migrations_path] || default_tenant_migration_path(repo)
 
-    Code.compiler_options(ignore_module_conflict: true)
-
     Ecto.Migration.SchemaMigration.ensure_schema_migrations_table!(
       repo,
       repo.config(),
@@ -44,8 +42,6 @@ defmodule AshPostgres.MultiTenancy do
 
       Ecto.Migration.SchemaMigration.up(repo, repo.config(), version, prefix: tenant_name)
     end)
-  after
-    Code.compiler_options(ignore_module_conflict: false)
   end
 
   # sobelow_skip ["SQL"]


### PR DESCRIPTION
This fixes the problem of logging "redefining module" entries when using context-driven multitenancy (where each tenant tries to compile the migration module).

[Fixes #480]
