### PR TITLE
[WIP] Redefine private function, prepare_opts

### DIFF
--- a/lib/repo.ex
+++ b/lib/repo.ex
@@ -182,6 +182,15 @@ defmodule AshPostgres.Repo do
 
       def on_transaction_begin(_reason), do: :ok
 
+      # copied from Ecto.Repo
+      defp ash_postgres_prepare_opts(operation_name, []), do: default_options(operation_name)
+
+      defp ash_postgres_prepare_opts(operation_name, [{key, _} | _rest] = opts) when is_atom(key) do
+        operation_name
+        |> default_options()
+        |> Keyword.merge(opts)
+      end
+
       def insert(struct_or_changeset, opts \\ []) do
         struct_or_changeset
         |> to_ecto()
@@ -192,7 +201,7 @@ defmodule AshPostgres.Repo do
             __MODULE__,
             repo,
             value,
-            Ecto.Repo.Supervisor.tuplet(repo, prepare_opts(:insert, opts))
+            Ecto.Repo.Supervisor.tuplet(repo, ash_postgres_prepare_opts(:insert, opts))
           )
         end)
         |> from_ecto()
@@ -208,7 +217,7 @@ defmodule AshPostgres.Repo do
             __MODULE__,
             repo,
             value,
-            Ecto.Repo.Supervisor.tuplet(repo, prepare_opts(:insert, opts))
+            Ecto.Repo.Supervisor.tuplet(repo, ash_postgres_prepare_opts(:insert, opts))
           )
         end)
         |> from_ecto()

--- a/lib/repo.ex
+++ b/lib/repo.ex
@@ -183,8 +183,6 @@ defmodule AshPostgres.Repo do
       def on_transaction_begin(_reason), do: :ok
 
       # copied from Ecto.Repo
-      def default_options(_operation), do: []
-
       defp ash_postgres_prepare_opts(operation_name, []),
         do: default_options(operation_name)
 

--- a/lib/repo.ex
+++ b/lib/repo.ex
@@ -183,9 +183,13 @@ defmodule AshPostgres.Repo do
       def on_transaction_begin(_reason), do: :ok
 
       # copied from Ecto.Repo
-      defp ash_postgres_prepare_opts(operation_name, []), do: default_options(operation_name)
+      def default_options(_operation), do: []
 
-      defp ash_postgres_prepare_opts(operation_name, [{key, _} | _rest] = opts) when is_atom(key) do
+      defp ash_postgres_prepare_opts(operation_name, []),
+        do: default_options(operation_name)
+
+      defp ash_postgres_prepare_opts(operation_name, [{key, _} | _rest] = opts)
+           when is_atom(key) do
         operation_name
         |> default_options()
         |> Keyword.merge(opts)


### PR DESCRIPTION
### Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests

Per chat in Discord

Redefine private function as it's causing issue when trying to set up `fly_postgres`

```
2 doctests, 2 properties, 463 tests, 0 failures
```