### PR TITLE
fix: Use `exclusion_constraint` instead of `check_constraint` in `add_exclusion_constraints`

### DIFF
--- a/lib/data_layer.ex
+++ b/lib/data_layer.ex
@@ -2555,13 +2555,13 @@ defmodule AshPostgres.DataLayer do
         {key, name} ->
           case repo.default_constraint_match_type(:check, name) do
             {:regex, regex} ->
-              Ecto.Changeset.check_constraint(changeset, key,
+              Ecto.Changeset.exclusion_constraint(changeset, key,
                 name: regex,
                 match: :exact
               )
 
             match ->
-              Ecto.Changeset.check_constraint(changeset, key,
+              Ecto.Changeset.exclusion_constraint(changeset, key,
                 name: name,
                 match: match
               )
@@ -2570,14 +2570,14 @@ defmodule AshPostgres.DataLayer do
         {key, name, message} ->
           case repo.default_constraint_match_type(:check, name) do
             {:regex, regex} ->
-              Ecto.Changeset.check_constraint(changeset, key,
+              Ecto.Changeset.exclusion_constraint(changeset, key,
                 name: regex,
                 message: message,
                 match: :exact
               )
 
             match ->
-              Ecto.Changeset.check_constraint(changeset, key,
+              Ecto.Changeset.exclusion_constraint(changeset, key,
                 name: name,
                 message: message,
                 match: match


### PR DESCRIPTION
[#1833](https://github.com/ash-project/ash/issues/1833)

With this change output becomes:
```
iex(12)> Ash.create booking

13:26:15.596 [debug] QUERY ERROR source="bookings" db=1.7ms queue=1.3ms idle=1920.5ms
INSERT INTO "bookings" ("start","duration","inserted_at","user_id") VALUES ($1,$2,$3,$4) RETURNING "user_id","inserted_at","duration","start","id" [~N[2025-03-02 11:59:15], 10000, ~U[2025-03-02 12:26:15.581059Z], 1]
{:error,
 %Ash.Error.Invalid{
   bread_crumbs: ["Error returned from: Bella.Bookings.Booking.create"], 
   changeset: "#Changeset<>", 
   errors: [
     %Ash.Error.Changes.InvalidAttribute{
       field: :start,
       message: "overlap error",
       private_vars: [
         constraint: "bookings_cannot_overlap",
         constraint_type: :exclusion
       ],
       value: nil,
       splode: Ash.Error,
       bread_crumbs: ["Error returned from: Bella.Bookings.Booking.create"],
       vars: [],
       path: [],
       stacktrace: #Splode.Stacktrace<>,
       class: :invalid
     }
   ]
 }}
```

### Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests
