### PR TITLE
fix: order when renaming attribute with an index

### DIFF
--- a/lib/migration_generator/migration_generator.ex
+++ b/lib/migration_generator/migration_generator.ex
@@ -1376,6 +1376,19 @@ defmodule AshPostgres.MigrationGenerator do
   end
 
   defp after?(
+         %Operation.AddCustomIndex{
+           table: table,
+           schema: schema
+         },
+         %Operation.RenameAttribute{
+           table: table,
+           schema: schema
+         }
+       ) do
+    true
+  end
+
+  defp after?(
          %Operation.AddReferenceIndex{
            table: table,
            schema: schema


### PR DESCRIPTION
When changing attribute with a custom index, recreate the index after table change.

closes https://github.com/ash-project/ash_postgres/issues/259

### Contributor checklist

- [x] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests
