### PR TITLE
bump: tool versions

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-erlang 27.0.1
-elixir 1.18.4-otp-27
+erlang 27.1.2
+elixir 1.18.4


### PR DESCRIPTION
Related to [issue](https://github.com/ash-project/ash/pull/2078) I was having.

Might be an issue on my end but with current tools versions on main:
```
erlang 27.0.1
elixir 1.18.4-otp-27
```
I couldn't compile:
```
error: Duration.__struct__/0 is undefined, cannot expand struct Duration. Make sure the struct name is correct. If the struct name exists and is correct but it still cannot be found, you likely have cyclic module usage in your code
  lib/ash/type/duration.ex:27: Ash.Type.Duration.matches_type?/2


== Compilation error in file lib/ash/type/duration.ex ==
** (CompileError) lib/ash/type/duration.ex: cannot compile module Ash.Type.Duration (errors have been logged)
    lib/ash/type/duration.ex:27: (module)
could not compile dependency :ash, "mix compile" failed. Errors may have been logged above. You can recompile this dependency with "mix deps.compile ash --force", update it with "mix deps.update ash" or clean it with "mix deps.clean ash"
```
But with tools versions that's on ash:
```
erlang 27.1.2
elixir 1.18.4
```
ash postgres compiles.

Weird. 😕 

### Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests
