### PR TITLE
fix: add failing test for `type()` in expression

### DIFF
--- a/test/support/resources/post.ex
+++ b/test/support/resources/post.ex
@@ -154,6 +154,12 @@ defmodule AshPostgres.Test.Post do
 
     defaults([:read, :destroy])
 
+    read :with_version_check do
+      argument(:version, :integer)
+
+      filter(expr(type(^arg(:version), :string) in ["1", "2"]))
+    end
+
     read :first_and_last_post do
       prepare(fn query, _ ->
         Ash.Query.combination_of(query, [

--- a/test/type_test.exs
+++ b/test/type_test.exs
@@ -100,4 +100,11 @@ defmodule AshPostgres.Test.TypeTest do
     assert %{x: 2.0, y: 3.0, z: 4.0} = p.db_string_point_id
     assert %{x: 2.0, y: 3.0, z: 4.0} = p.db_string_point.id
   end
+
+  test "casting integer to string works" do
+    Post |> Ash.Changeset.for_create(:create) |> Ash.create!()
+
+    post = Ash.Query.for_read(Post, :with_version_check, version: 1) |> Ash.read!()
+    refute is_nil(post)
+  end
 end


### PR DESCRIPTION
This commit currently only adds a failing test.

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
