### PR TITLE
fix: smallserial not mapping to proper type

### DIFF
--- a/lib/resource_generator/spec.ex
+++ b/lib/resource_generator/spec.ex
@@ -958,7 +958,7 @@ defmodule AshPostgres.ResourceGenerator.Spec do
   defp type("numeric"), do: {:ok, :decimal}
   defp type("decimal"), do: {:ok, :decimal}
   defp type("smallint"), do: {:ok, :integer}
-  defp type("smallserial"), do: {:ok, :ineger}
+  defp type("smallserial"), do: {:ok, :integer}
   defp type("serial"), do: {:ok, :integer}
   defp type("text"), do: {:ok, :string}
   defp type("time"), do: {:ok, :time}


### PR DESCRIPTION
Small typo I noticed while looking at the code. No idea on the impact. I don't think these are tested or at least I couldn't find any test so I didn't bother with that.

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies