### PR TITLE
refactor: use multiline string templates to preserve escapes in checks

### DIFF
--- a/lib/migration_generator/operation.ex
+++ b/lib/migration_generator/operation.ex
@@ -1351,10 +1351,20 @@ defmodule AshPostgres.MigrationGenerator.Operation do
           },
           table: table
         }) do
+      prefix = if schema, do: ", " <> option(:prefix, schema), else: ""
+
       if base_filter do
-        "create constraint(:#{as_atom(table)}, :#{as_atom(name)}, #{join(["check: \"(#{check}) OR NOT (#{base_filter})\")", option(:prefix, schema)])}"
+        ~s'''
+        create constraint(:#{as_atom(table)}, :#{as_atom(name)}, check: """
+          (#{check}) OR NOT (#{base_filter})
+        """#{prefix})
+        '''
       else
-        "create constraint(:#{as_atom(table)}, :#{as_atom(name)}, #{join(["check: \"#{check}\")", option(:prefix, schema)])}"
+        ~s'''
+        create constraint(:#{as_atom(table)}, :#{as_atom(name)}, check: """
+          #{check}
+        """#{prefix})
+        '''
       end
     end
 
@@ -1386,10 +1396,20 @@ defmodule AshPostgres.MigrationGenerator.Operation do
           schema: schema,
           table: table
         }) do
+      prefix = if schema, do: ", " <> option(:prefix, schema), else: ""
+
       if base_filter do
-        "create constraint(:#{as_atom(table)}, :#{as_atom(name)}, #{join(["check: \"#{base_filter} AND #{check}\")", option(:prefix, schema)])}"
+        ~s'''
+        create constraint(:#{as_atom(table)}, :#{as_atom(name)}, check: """
+          #{base_filter} AND #{check}
+        """#{prefix})
+        '''
       else
-        "create constraint(:#{as_atom(table)}, :#{as_atom(name)}, #{join(["check: \"#{check}\")", option(:prefix, schema)])}"
+        ~s'''
+        create constraint(:#{as_atom(table)}, :#{as_atom(name)}, check: """
+          #{check}
+        """#{prefix})
+        '''
       end
     end
   end


### PR DESCRIPTION
# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] Bug fixes include regression tests
- [x] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [x] Refactoring
- [ ] Update dependencies

As discussed in previously closed pull request, this is a simplified refactor of the check constraint generator that cleanly preserves escaped content in check constraints.