### PR TITLE
fix: ensure tenant prefix is set only for resources with context multitenancy

### DIFF
--- a/lib/data_layer.ex
+++ b/lib/data_layer.ex
@@ -893,8 +893,12 @@ defmodule AshPostgres.DataLayer do
   end
 
   @impl true
-  def set_tenant(_resource, query, tenant) do
-    {:ok, Map.put(Ecto.Query.put_query_prefix(query, to_string(tenant)), :__tenant__, tenant)}
+  def set_tenant(resource, query, tenant) do
+    if Ash.Resource.Info.multitenancy_strategy(resource) == :context do
+      {:ok, Map.put(Ecto.Query.put_query_prefix(query, to_string(tenant)), :__tenant__, tenant)}
+    else
+      {:ok, query}
+    end
   end
 
   @impl true


### PR DESCRIPTION
This fixes attribute multitenancy which is currently broken by this commit https://github.com/ash-project/ash_postgres/commit/60ab568d6747a98ad6db9ceae86c663397e54bac

I thought updating set_tenant is the proper way to do it since it currently just adds the prefix to the query which only makes sense in context multitenancy 

Maybe attribute multitenancy can be handled there too? .. by adding a filter or something, but it currently seems to be handled somewhere else (not sure where) but I see the multitennacy attribute filter is added to my update queries.
