### PR TITLE
(fix) For renamed & modified attributes, use new attribute source in down migration

### DIFF
--- a/lib/migration_generator/operation.ex
+++ b/lib/migration_generator/operation.ex
@@ -752,7 +752,7 @@ defmodule AshPostgres.MigrationGenerator.Operation do
       up(%{
         op
         | old_attribute: op.new_attribute,
-          new_attribute: op.old_attribute,
+          new_attribute: Map.put(op.old_attribute, :source, op.new_attribute.source),
           old_multitenancy: op.multitenancy,
           multitenancy: op.old_multitenancy
       })


### PR DESCRIPTION
fix(#582) For renamed & modified attributes, use new attribute source in down migration
    
When an attribute is renamed, alongside other changes to it (like changing default or not null constraint), the generated up migration first renames the column, then modifies it.
    
For the generated down migration, the order of operations is reversed, so we need to use the new column name when modifying the column, before renaming it back.

(i) There is one test failing for me locally, that I think is unrelated to this change (it's also failing on `main`)

### Contributor checklist

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
  - (modified existing unit test)
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
