### PR TITLE
add a test for default sort referencing parent field in many_to_many …

### DIFF
--- a/test/parent_sort_test.ex
+++ b/test/parent_sort_test.ex
@@ -1,0 +1,32 @@
+defmodule AshPostgres.Test.ParentSortTest do
+  use AshPostgres.RepoCase, async: false
+
+  alias AshPostgres.Test.{Organization, Post, User}
+
+  require Ash.Query
+
+  test "can reference parent field when declaring default sort in has_many no_attributes? relationship" do
+    organization =
+      Organization
+      |> Ash.Changeset.for_create(:create, %{name: "test_org"})
+      |> Ash.create!()
+
+    user =
+      User
+      |> Ash.Changeset.for_create(:create, %{organization_id: organization.id, name: "foo bar"})
+      |> Ash.create!()
+
+    Post
+    |> Ash.Changeset.for_create(:create, %{organization_id: organization.id})
+    |> Ash.create!()
+
+    Post
+    |> Ash.Changeset.for_create(:create, %{organization_id: organization.id, title: "test_org"})
+    |> Ash.create!()
+
+    assert {:ok, _} =
+             Post
+             |> Ash.Query.load(:recommendations)
+             |> Ash.read(authorize?: false)
+  end
+end

--- a/test/support/resources/post.ex
+++ b/test/support/resources/post.ex
@@ -614,6 +614,12 @@ defmodule AshPostgres.Test.Post do
       filter(expr(fragment("? = ?", title, parent(organization.name))))
     end
 
+    has_many(:recommendations, __MODULE__) do
+      public?(true)
+      no_attributes?(true)
+      sort([calc(fragment("abs(extract epoch from ?))", parent(datetime) - datetime))])
+    end
+
     belongs_to :parent_post, __MODULE__ do
       public?(true)
     end


### PR DESCRIPTION
…relationship with no_attributes? true

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
