### PR TITLE
Demonstrate failed query for is_nil on array within jsonb

### DIFF
--- a/test/storage_types_test.exs
+++ b/test/storage_types_test.exs
@@ -66,6 +66,7 @@ defmodule AshPostgres.StorageTypesTest do
              |> Ash.read!()
   end
 
+  @tag capture_log: false
   test "`is_nil` operator works on get_path results" do
     %{id: id} =
       Author
@@ -85,7 +86,7 @@ defmodule AshPostgres.StorageTypesTest do
 
     assert [%Author{id: ^id}] =
              Author
-             |> Ash.Query.filter(is_nil(settings["optional_field"]))
+             |> Ash.Query.filter(is_nil(settings["dues_reminders"]))
              |> Ash.read!()
   end
 end

--- a/test/support/resources/author.ex
+++ b/test/support/resources/author.ex
@@ -30,7 +30,7 @@ defmodule AshPostgres.Test.Author do
     attribute(:bio, AshPostgres.Test.Bio, public?: true)
     attribute(:bios, {:array, :map}, public?: true)
     attribute(:badges, {:array, :atom}, public?: true)
-    attribute(:settings, :map, public?: true)
+    attribute(:settings, AshPostgres.Test.Settings, public?: true)
   end
 
   actions do

--- a/test/support/resources/settings.ex
+++ b/test/support/resources/settings.ex
@@ -1,0 +1,10 @@
+defmodule AshPostgres.Test.Settings do
+  @moduledoc false
+  use Ash.Resource, data_layer: :embedded
+
+  attributes do
+    attribute :dues_reminders, {:array, :string}, public?: true
+    attribute :newsletter, {:array, :string}, public?: true
+    attribute :optional_field, :string, public?: true
+  end
+end


### PR DESCRIPTION
# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

Demonstrates the bug when translating an Ash.Query into SQL, by modifying the test that was recently added. Here's the test output:

```
  1) test `is_nil` operator works on get_path results (AshPostgres.StorageTypesTest)
     test/storage_types_test.exs:70
     ** (Ash.Error.Unknown) 
     Bread Crumbs:
       > Error returned from: AshPostgres.Test.Author.read

     Unknown Error

     * ** (Postgrex.Error) ERROR 22P02 (invalid_text_representation) malformed array literal: "["email", "sms"]". If you are trying to query a JSON field, the parameter may need to be interpolated. Instead of

         p.json["field"] != "value"

     do

         p.json["field"] != ^"value"


     "[" must introduce explicitly-specified array dimensions.
```

The debug logging output shows that ash_postgres is trying to cast the return value of `jsonb_extract_path_text()` with `::text[]`, which is apparently invalid. Changing the cast to `::jsonb[]` should fix it.