### PR TITLE
fix: use default constraint of 'now()' for AshPostgres.Timestamptz

### DIFF
--- a/lib/migration_generator/migration_generator.ex
+++ b/lib/migration_generator/migration_generator.ex
@@ -3489,7 +3489,7 @@ defmodule AshPostgres.MigrationGenerator do
 
   @uuid_functions [&Ash.UUID.generate/0, &Ecto.UUID.generate/0]
 
-  defp default(%{name: name, default: default}, resource, _repo) when is_function(default) do
+  defp default(%{name: name, default: default, type: type}, resource, _repo) when is_function(default) do
     configured_default(resource, name) ||
       cond do
         default in @uuid_functions ->
@@ -3497,6 +3497,9 @@ defmodule AshPostgres.MigrationGenerator do
 
         default == (&Ash.UUIDv7.generate/0) ->
           ~S[fragment("uuid_generate_v7()")]
+
+        default == (&DateTime.utc_now/0) && type == AshPostgres.Timestamptz ->
+          ~S[fragment("now()")]
 
         default == (&DateTime.utc_now/0) ->
           ~S[fragment("(now() AT TIME ZONE 'utc')")]


### PR DESCRIPTION
NOTE: I haven't included any testing as it's unclear to me that there exist any tests for default constraint generators. I noticed that at least one previous patch applied to this region didn't include tests. LMK if I should do anything differently.

AshPostgres.Timestamptz creates a pg column of type 'timestamptz', however the existing default behaviour was to implement the default constraint as a 'timestamp' type. Effectively 'now()::timestamptz' was converted to 'timestamp' then back to 'timestamptz'. This has been changed to 'now()'.

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
