### PR TITLE
chore: remove deprecated script documentation; fix mise confusion in .tool-versions

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
 erlang 27.1.2
-elixir 1.18.4
+elixir 1.18.4-otp-27

--- a/documentation/topics/development/migrations-and-tasks.md
+++ b/documentation/topics/development/migrations-and-tasks.md
@@ -23,35 +23,6 @@ For more information on generating migrations, run `mix help ash_postgres.genera
 >
 > If you have are using schema-based multitenancy, you will also need to define a `all_tenants/0` function in your repo module. See `AshPostgres.Repo` for more.
 
-### Regenerating Migrations
-
-Often, you will run into a situation where you want to make a slight change to a resource after you've already generated and run migrations. If you are using git and would like to undo those changes, then regenerate the migrations, this script may prove useful:
-
-```bash
-#!/bin/bash
-
-# Get count of untracked migrations
-N_MIGRATIONS=$(git ls-files --others priv/repo/migrations | wc -l)
-
-# Rollback untracked migrations
-mix ash_postgres.rollback -n $N_MIGRATIONS
-
-# Delete untracked migrations and snapshots
-git ls-files --others priv/repo/migrations | xargs rm
-git ls-files --others priv/resource_snapshots | xargs rm
-
-# Regenerate migrations
-mix ash.codegen --name $1
-
-# Run migrations if flag
-if echo $* | grep -e "-m" -q
-then
-  mix ash.migrate
-fi
-```
-
-After saving this file to something like `regen.sh`, make it executable with `chmod +x regen.sh`. Now you can run it with `./regen.sh name_of_operation`. If you would like the migrations to automatically run after regeneration, add the `-m` flag: `./regen.sh name_of_operation -m`.
-
 ## Running Migrations in Production
 
 Define a module similar to the following:


### PR DESCRIPTION
# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [x] Chores
- [x] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

For context on `mise` and `.tool-verions`: If a higher version of OTP is available for an Elixir version than the selected Erlang version, it results in an OTP mismatch error.