### PR TITLE
feat(aggregates): add multitenancy bypass for context

### DIFF
--- a/priv/test_repo/tenant_migrations/20220805191441_migrate_resources1.exs
+++ b/priv/test_repo/tenant_migrations/20220805191441_migrate_resources1.exs
@@ -15,6 +15,8 @@ defmodule AshPostgres.TestRepo.TenantMigrations.MigrateResources1 do
     create table(:multitenant_posts, primary_key: false, prefix: prefix()) do
       add :id, :uuid, null: false, default: fragment("uuid_generate_v4()"), primary_key: true
       add :name, :text
+      add :score, :integer
+      add :rating, :decimal
 
       add :org_id,
           references(:multitenant_orgs,

--- a/test/support/multitenancy/resources/org.ex
+++ b/test/support/multitenancy/resources/org.ex
@@ -66,6 +66,38 @@ defmodule AshPostgres.MultitenancyTest.Org do
   aggregates do
     count(:total_users_posts, [:users, :posts])
     count(:total_posts, :posts)
+
+    # Bypass aggregates for posts relationship
+    count :posts_count_all_tenants, :posts do
+      public?(true)
+      multitenancy :bypass
+    end
+
+    count :posts_count_current_tenant, :posts do
+      public?(true)
+    end
+
+    list :post_names_all_tenants, :posts, :name do
+      public?(true)
+      multitenancy :bypass
+    end
+
+    list :post_names_current_tenant, :posts, :name do
+      public?(true)
+    end
+
+    count :users_count, :users do
+      public?(true)
+    end
+
+    list :user_names, :users, :name do
+      public?(true)
+    end
+
+    exists :has_posts_all_tenants, :posts do
+      public?(true)
+      multitenancy :bypass
+    end
   end
 
   relationships do

--- a/test/support/multitenancy/resources/post.ex
+++ b/test/support/multitenancy/resources/post.ex
@@ -23,6 +23,8 @@ defmodule AshPostgres.MultitenancyTest.Post do
   attributes do
     uuid_primary_key(:id, writable?: true)
     attribute(:name, :string, public?: true)
+    attribute(:score, :integer, public?: true)
+    attribute(:rating, :decimal, public?: true)
   end
 
   actions do
@@ -85,5 +87,29 @@ defmodule AshPostgres.MultitenancyTest.Post do
 
   calculations do
     calculate(:last_word, :string, expr(fragment("split_part(?, ' ', -1)", name)))
+  end
+
+  aggregates do
+    # COUNT Aggregates WITH bypass for context multitenancy
+    count :total_linked_posts_all_tenants, :linked_posts do
+      public?(true)
+      multitenancy :bypass
+    end
+
+    # COUNT Aggregates WITHOUT bypass for context multitenancy
+    count :total_linked_posts_current_tenant, :linked_posts do
+      public?(true)
+    end
+
+    # EXISTS Aggregate WITH bypass
+    exists :has_linked_posts_all_tenants, :linked_posts do
+      public?(true)
+      multitenancy :bypass
+    end
+
+    # EXISTS Aggregate WITHOUT bypass
+    exists :has_linked_posts_current_tenant, :linked_posts do
+      public?(true)
+    end
   end
 end

--- a/test/support/multitenancy/resources/user.ex
+++ b/test/support/multitenancy/resources/user.ex
@@ -47,6 +47,84 @@ defmodule AshPostgres.MultitenancyTest.User do
   aggregates do
     list(:years_visited, :posts, :last_word)
     count(:count_visited, :posts)
+
+    # Bypass aggregates for testing context multitenancy
+    count :posts_count_all_tenants, :posts do
+      public?(true)
+      multitenancy :bypass
+    end
+
+    count :posts_count_current_tenant, :posts do
+      public?(true)
+    end
+
+    list :post_names_all_tenants, :posts, :name do
+      public?(true)
+      multitenancy :bypass
+    end
+
+    list :post_names_current_tenant, :posts, :name do
+      public?(true)
+    end
+
+    exists :has_posts_all_tenants, :posts do
+      public?(true)
+      multitenancy :bypass
+    end
+
+    exists :has_posts_current_tenant, :posts do
+      public?(true)
+    end
+
+    # SUM aggregates
+    sum :total_score_all_tenants, :posts, :score do
+      public?(true)
+      multitenancy :bypass
+    end
+
+    sum :total_score_current_tenant, :posts, :score do
+      public?(true)
+    end
+
+    # AVG aggregates
+    avg :avg_score_all_tenants, :posts, :score do
+      public?(true)
+      multitenancy :bypass
+    end
+
+    avg :avg_score_current_tenant, :posts, :score do
+      public?(true)
+    end
+
+    # MAX aggregates
+    max :max_score_all_tenants, :posts, :score do
+      public?(true)
+      multitenancy :bypass
+    end
+
+    max :max_score_current_tenant, :posts, :score do
+      public?(true)
+    end
+
+    # MIN aggregates
+    min :min_score_all_tenants, :posts, :score do
+      public?(true)
+      multitenancy :bypass
+    end
+
+    min :min_score_current_tenant, :posts, :score do
+      public?(true)
+    end
+
+    # FIRST aggregates
+    first :first_post_name_all_tenants, :posts, :name do
+      public?(true)
+      multitenancy :bypass
+    end
+
+    first :first_post_name_current_tenant, :posts, :name do
+      public?(true)
+    end
   end
 
   def parse_tenant("org_" <> id), do: id


### PR DESCRIPTION
Based on https://github.com/ash-project/ash/pull/2427 for bypassing context aggregates

**Please for testing change the Ash to https://github.com/ash-project/ash/pull/2427  PR**; I did not change the mix.exs here so the tests are going to be failed


> Please review carefully; I might have missed something. Many parts were involved, but I tried to keep codebase changes minimal. All Ash tests passed successfully. It needs comprehensive checking the code, for example some place i could not be able to avg as sql, so i did in elixir

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [x] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
