### PR TITLE
test: add failing test for aggregate filtering on nested first aggregate

### DIFF
--- a/lib/verifiers/validate_check_constraints.ex
+++ b/lib/verifiers/validate_check_constraints.ex
@@ -33,4 +33,3 @@ defmodule AshPostgres.Verifiers.ValidateCheckConstraints do
     :ok
   end
 end
-

--- a/test/support/resources/comment.ex
+++ b/test/support/resources/comment.ex
@@ -60,6 +60,10 @@ defmodule AshPostgres.Test.Comment do
     list :linked_comment_post_ids, [:linked_comments, :post], :id do
       uniq?(true)
     end
+
+    first :latest_rating_score, :ratings, :score do
+      sort(score: :desc)
+    end
   end
 
   calculations do
@@ -73,6 +77,8 @@ defmodule AshPostgres.Test.Comment do
          "hello"
        end)}
     end)
+
+    calculate(:has_rating, :boolean, expr(not is_nil(latest_rating_score)))
   end
 
   relationships do

--- a/test/support/resources/post.ex
+++ b/test/support/resources/post.ex
@@ -1278,6 +1278,14 @@ defmodule AshPostgres.Test.Post do
     count :count_comments_with_modify_query, :comments do
       read_action(:with_modify_query)
     end
+
+    count :count_of_comments_with_ratings, :comments do
+      filter(expr(has_rating == true))
+    end
+
+    count :count_of_comments_with_high_ratings, :comments do
+      filter(expr(latest_rating_score > 5))
+    end
   end
 end
 


### PR DESCRIPTION
This adds a test to reproduce an error I encountered in our application when upgrading to the latest ash packages, in particular `ash_sql`.

A separate PR has been opened to fix the issue in `ash_sql`.

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
- [x] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
