### PR TITLE
add generator to tsvector type

### DIFF
--- a/lib/types/tsvector.ex
+++ b/lib/types/tsvector.ex
@@ -64,4 +64,9 @@ defmodule AshPostgres.Tsvector do
   def cast_stored(_, _) do
     :error
   end
+
+  @impl true
+  def generator(_constraints) do
+    StreamData.constant([])
+  end
 end


### PR DESCRIPTION
My team uses the Tsvector type, and we're trying to start using generators in tests, but tsvector currently doesn't have a generator so trying to generate something with it raises. This adds one that just always creates an empty list. I'm open to suggestions if you think the generator should be doing something more complex here—I assume this is a scenario where, if someone wants to be generating something specific for it in a test, they probably have a clear idea of what that is.

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [X] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
