### PR TITLE
test: binding error when loading aggregate

### DIFF
--- a/test/aggregate_test.exs
+++ b/test/aggregate_test.exs
@@ -136,7 +136,6 @@ defmodule AshSql.AggregateTest do
     |> Ash.Changeset.set_context(%{data_layer: %{table: "comment_ratings"}})
     |> Ash.create!()
 
-    # Key test scenario (matches heretask bug):
     # 1. Filter through :author adds a binding for the :author relationship
     # 2. Policy joins through has_many which adds DISTINCT
     # 3. limit(1) also triggers subquery wrapping condition
@@ -144,8 +143,6 @@ defmodule AshSql.AggregateTest do
     #    triggers wrap_in_subquery_for_aggregates
     # 5. Loading :author_first_name (optimizable first through belongs_to :author)
     #    after wrapping, code tries to reuse the :author binding from before wrapping
-    # 6. BUG: binding exists in __ash_bindings__ but points to inner subquery
-    # 7. Error: "could not find named binding `as(N)`"
     loaded_post =
       Post
       |> Ash.Query.filter(id == ^post.id and author.first_name == "John")


### PR DESCRIPTION
When upgrading our project to the latest ash package dependencies, I encountered a bug on an existing feature that was not previously present. The bug was introduced in a recent `ash_sql` commit.

I have used AI to create a fix for the issue, and also a test that reproduces the issue. I have verified that the test fails on `ash_sql` main and passes with the fix applied. The bug in our actual project is resolved by the fix, and all other tests pass.  There is one other failing test in ash_postgres that was already present.

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
- [x] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
