### PR TITLE
bugfix: Re-add `bulk_create_index` metadata when running bulk creates

### DIFF
--- a/lib/data_layer.ex
+++ b/lib/data_layer.ex
@@ -2142,8 +2142,12 @@ defmodule AshPostgres.DataLayer do
                     end
 
                     # Compatibility fallback
-                    Ash.Resource.put_metadata(
-                      result_for_changeset,
+                    result_for_changeset
+                    |> Ash.Resource.put_metadata(
+                      :bulk_create_index,
+                      changeset.context[:bulk_create][:index]
+                    )
+                    |> Ash.Resource.put_metadata(
                       :bulk_action_ref,
                       changeset.context[:bulk_create][:ref]
                     )
@@ -2159,8 +2163,12 @@ defmodule AshPostgres.DataLayer do
                   end
 
                   # Compatibility fallback
-                  Ash.Resource.put_metadata(
-                    result,
+                  result
+                  |> Ash.Resource.put_metadata(
+                    :bulk_create_index,
+                    changeset.context[:bulk_create][:index]
+                  )
+                  |> Ash.Resource.put_metadata(
                     :bulk_action_ref,
                     changeset.context[:bulk_create][:ref]
                   )

--- a/test/bulk_create_test.exs
+++ b/test/bulk_create_test.exs
@@ -579,4 +579,21 @@ defmodule AshPostgres.BulkCreateTest do
       end)
     end
   end
+
+  describe "bulk_create with sorted?: true" do
+    test "works without error" do
+      # This test reproduces https://github.com/ash-project/ash/issues/2452
+      # generate_many uses sorted?: true which requires bulk_create_index metadata
+      results =
+        Ash.bulk_create!(
+          [%{title: "post_1"}, %{title: "post_2"}, %{title: "post_3"}],
+          Post,
+          :create,
+          return_records?: true,
+          sorted?: true
+        )
+
+      assert length(results.records) == 3
+    end
+  end
 end


### PR DESCRIPTION
This is necessary when running bulk create actions with the `sorted?: true` option, and also retains consistency with other built-in data layers

Related to https://github.com/ash-project/ash/issues/2452 and https://github.com/ash-project/ash_postgres/commit/4b6463b82f46938f0ac7b13af4c57fc52ff1f2b2


# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
