### PR TITLE
test: Add failing test for timestamptz comparisons

### DIFF
--- a/test/support/resources/post.ex
+++ b/test/support/resources/post.ex
@@ -1159,6 +1159,9 @@ defmodule AshPostgres.Test.Post do
               ) do
       public?(true)
     end
+
+    calculate(:past_datetime1?, :boolean, expr(now() > datetime))
+    calculate(:past_datetime2?, :boolean, expr(datetime <= now()))
   end
 
   aggregates do


### PR DESCRIPTION
This PR adds a failing test for #651. The problem is that Ash casts `timestamptz` to `timestamp`, but only when the attribute is first in the comparison. See the discussion in #651 for more details.


# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
