### PR TITLE
fix: apply join_relationship filter/sort/limit in many_to_many lateral joins

### DIFF
--- a/test/support/resources/post.ex
+++ b/test/support/resources/post.ex
@@ -851,6 +851,31 @@ defmodule AshPostgres.Test.Post do
 
     has_many(:post_followers, AshPostgres.Test.PostFollower)
 
+    # For testing join_relationship limit inheritance
+    has_many :top_three_post_followers, AshPostgres.Test.PostFollower do
+      sort(order: :asc)
+      limit(3)
+    end
+
+    many_to_many(:top_three_followers, AshPostgres.Test.User,
+      join_relationship: :top_three_post_followers,
+      source_attribute_on_join_resource: :post_id,
+      destination_attribute_on_join_resource: :follower_id
+    )
+
+    # For testing join_relationship with filter+sort+limit inheritance
+    has_many :filtered_top_post_followers, AshPostgres.Test.PostFollower do
+      filter(expr(order > 1))
+      sort(order: :asc)
+      limit(2)
+    end
+
+    many_to_many(:filtered_top_followers, AshPostgres.Test.User,
+      join_relationship: :filtered_top_post_followers,
+      source_attribute_on_join_resource: :post_id,
+      destination_attribute_on_join_resource: :follower_id
+    )
+
     many_to_many(:sorted_followers, AshPostgres.Test.User,
       public?: true,
       through: AshPostgres.Test.PostFollower,


### PR DESCRIPTION
When a many_to_many relationship uses a join_relationship with sort/limit/filter, those constraints weren't being applied in the lateral join query.

Two issues:

1. The sort/limit/filter from the join_relationship weren't being added to the through_query at all
2. When the through_query is wrapped in a subquery, the parent correlation needs to be inside the subquery so the limit applies per-parent

This is related to https://github.com/ash-project/ash/pull/2486 (hence why some of the code is the same) but for Postgres, which uses lateral joins.

(Claude was used in investigating and fixing this bug)

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
