### PR TITLE
bug: Add test verifying a bug in AshSql with `has_many` with `limit` and `sort` not respected in `exists` query filters

### DIFF
--- a/test/support/resources/comment.ex
+++ b/test/support/resources/comment.ex
@@ -113,6 +113,13 @@ defmodule AshPostgres.Test.Comment do
       relationship_context: %{data_layer: %{table: "comment_ratings"}}
     )
 
+    has_many :top_ratings, AshPostgres.Test.Rating do
+      destination_attribute(:resource_id)
+      relationship_context(%{data_layer: %{table: "comment_ratings"}})
+      sort(score: :desc)
+      limit(2)
+    end
+
     has_many(:popular_ratings, AshPostgres.Test.Rating,
       public?: true,
       destination_attribute: :resource_id,


### PR DESCRIPTION
This test currently fails, and the fix is in https://github.com/ash-project/ash_sql/pull/198 :)

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
