### PR TITLE
Update mix.exs, remove deprecated :preferred_cli_env

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -21,18 +21,7 @@ defmodule AshPostgres.MixProject do
       description: @description,
       elixirc_paths: elixirc_paths(Mix.env()),
       consolidate_protocols: Mix.env() == :prod,
-      preferred_cli_env: [
-        coveralls: :test,
-        "coveralls.github": :test,
-        "test.create": :test,
-        "test.migrate": :test,
-        "test.rollback": :test,
-        "test.migrate_tenants": :test,
-        "test.check_migrations": :test,
-        "test.drop": :test,
-        "test.generate_migrations": :test,
-        "test.reset": :test
-      ],
+      cli: cli(),
       dialyzer: [
         plt_add_apps: [:ecto, :ash, :mix]
       ],
@@ -51,6 +40,23 @@ defmodule AshPostgres.MixProject do
         mod: {AshPostgres.TestApp, []}
       ]
     end
+  end
+
+  defp cli do
+    [
+      preferred_cli_env: [
+        coveralls: :test,
+        "coveralls.github": :test,
+        "test.create": :test,
+        "test.migrate": :test,
+        "test.rollback": :test,
+        "test.migrate_tenants": :test,
+        "test.check_migrations": :test,
+        "test.drop": :test,
+        "test.generate_migrations": :test,
+        "test.reset": :test
+      ]
+    ]
   end
 
   defp elixirc_paths(:test), do: ["lib", "test/support"]


### PR DESCRIPTION
Resolves this warning for elixir > 1.19
```
warning: setting :preferred_cli_env in your mix.exs "def project" is deprecated, set it inside "def cli" instead:

    def cli do
      [preferred_envs: [coveralls: :test, "coveralls.github": :test, "test.create": :test, "test.migrate": :test, "test.rollback": :test, "test.migrate_tenants": :test, "test.check_migrations"
: :test, "test.drop": :test, "test.generate_migrations": :test, "test.reset": :test]]
    end
```

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
