### PR TITLE
fix: correct test expectation for `first` aggregate with `include_nil?`

### DIFF
--- a/test/aggregate_test.exs
+++ b/test/aggregate_test.exs
@@ -874,7 +874,9 @@ defmodule AshSql.AggregateTest do
       |> Ash.Changeset.manage_relationship(:post, post, type: :append_and_remove)
       |> Ash.create!()
 
-      assert "match" ==
+      # With sort(title: :asc_nils_first), nil comes first.
+      # With include_nil?: true, we should get nil (not skip to the next non-nil value)
+      assert nil ==
                Post
                |> Ash.Query.filter(id == ^post.id)
                |> Ash.Query.load(:first_comment_nils_first_include_nil)


### PR DESCRIPTION
The test was asserting buggy behavior. With `sort(title: :asc_nils_first)` and `include_nil?: true`, the `first` aggregate should return `nil` when the first sorted record has a nil value, not skip to the next non-nil value.

The fix to make this updated test actually pass is in ash_sql here - https://github.com/ash-project/ash_sql/pull/210

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
