### PR TITLE
Let MigrationGenerator use custom :migration_source

### DIFF
--- a/lib/migration_generator/migration_generator.ex
+++ b/lib/migration_generator/migration_generator.ex
@@ -540,7 +540,7 @@ defmodule AshPostgres.MigrationGenerator do
     if tenant? do
       Ecto.Migrator.with_repo(repo, fn repo ->
         for prefix <- repo.all_tenants() do
-          {repo, query, opts} = Ecto.Migration.SchemaMigration.versions(repo, [], prefix)
+          {repo, query, opts} = Ecto.Migration.SchemaMigration.versions(repo, repo.config(), prefix)
 
           repo.transaction(fn ->
             versions = repo.all(query, Keyword.put(opts, :timeout, :infinity))
@@ -574,7 +574,7 @@ defmodule AshPostgres.MigrationGenerator do
       end)
     else
       Ecto.Migrator.with_repo(repo, fn repo ->
-        {repo, query, opts} = Ecto.Migration.SchemaMigration.versions(repo, [], nil)
+        {repo, query, opts} = Ecto.Migration.SchemaMigration.versions(repo, repo.config(), nil)
 
         repo.transaction(fn ->
           versions = repo.all(query, opts)


### PR DESCRIPTION
Without taking into account the repo’s config the schema migration versions lookup fails because of a non-existing table and the Mix task `ash.codegen` aborts.

Fixes #687.

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
