### PR TITLE
Fix issue #433: correct destroy behavior

### DIFF
--- a/test/destroy_test.exs
+++ b/test/destroy_test.exs
@@ -4,7 +4,30 @@
 
 defmodule AshPostgres.DestroyTest do
   use AshPostgres.RepoCase, async: false
-  alias AshPostgres.Test.Post
+  alias AshPostgres.Test.{Post, Permalink}
+
+  test "destroy with restrict on_delete returns would leave records behind error" do
+    post =
+      Post
+      |> Ash.Changeset.for_create(:create, %{})
+      |> Ash.create!()
+
+    Permalink |> Ash.Changeset.for_create(:create, %{post_id: post.id}) |> Ash.create!()
+
+    assert {:error, %Ash.Error.Invalid{errors: errors}} =
+             post
+             |> Ash.Changeset.for_destroy(:destroy, %{})
+             |> Ash.destroy()
+
+    assert Enum.any?(errors, fn
+             %Ash.Error.Changes.InvalidAttribute{message: msg} ->
+               msg =~ "would leave records behind"
+
+             _ ->
+               false
+           end),
+           "Expected 'would leave records behind' error, got: #{inspect(errors)}"
+  end
 
   test "destroy action destroys the record" do
     post =


### PR DESCRIPTION
# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x ] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ x] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

To address this error I added logic for the [] case. If the error is a foreign key violation and includes a constraint name, I extract it and pass it through the same constraints_to_errors pipeline. That produces the would leave records behind message when there’s a matching constraint on the changeset. If it’s not a foreign key violation or I can't extract it, I keep the previous behavior and return the raw error.