### PR TITLE
fix: correct prefix name when loading many_to_many relationships

### DIFF
--- a/lib/data_layer.ex
+++ b/lib/data_layer.ex
@@ -1323,7 +1323,7 @@ defmodule AshPostgres.DataLayer do
                   through_query.limit != nil || through_query.order_bys != [] ||
                     (through_query.joins && through_query.joins != []) ||
                     has_subqueries_in_wheres? ||
-                    (Ash.Resource.Info.multitenancy_strategy(through_relationship.source) ==
+                    (Ash.Resource.Info.multitenancy_strategy(through_resource.resource) ==
                        :context &&
                        source_query.tenant)
 
@@ -1340,11 +1340,11 @@ defmodule AshPostgres.DataLayer do
                       set_subquery_prefix(
                         through_query,
                         source_query,
-                        through_relationship.source
+                        through_resource.resource
                       )
                     )
                   else
-                    set_subquery_prefix(through_query, source_query, through_relationship.source)
+                    set_subquery_prefix(through_query, source_query, through_resource.resource)
                   end
 
                 if query.__ash_bindings__[:__order__?] do
@@ -2536,7 +2536,7 @@ defmodule AshPostgres.DataLayer do
 
     fields_to_upsert =
       upsert_fields --
-        Keyword.keys(Enum.at(changesets, 0).atomics) -- keys
+        (Keyword.keys(Enum.at(changesets, 0).atomics) -- keys)
 
     fields_to_upsert =
       case fields_to_upsert do

--- a/priv/test_repo/migrations/20260414095619_add_cross_schema_many_to_many_test.exs
+++ b/priv/test_repo/migrations/20260414095619_add_cross_schema_many_to_many_test.exs
@@ -1,0 +1,58 @@
+defmodule AshPostgres.TestRepo.Migrations.AddCrossSchemaM2MTest do
+  @moduledoc """
+  Migration for cross-schema many_to_many regression test.
+
+  Creates:
+  - "interest" schema
+  - interests table in "interest" schema
+  - profile_interests table in "profiles" schema (join table)
+
+  This tests true cross-schema many_to_many between two custom schemas:
+  - Interest in "interest" schema
+  - Profile in "profiles" schema
+  - ProfileInterest join table in "profiles" schema
+  """
+  use Ecto.Migration
+
+  def up do
+    # Create the "interest" schema
+    execute "CREATE SCHEMA IF NOT EXISTS interest"
+
+    # Interest table in "interest" schema
+    create table(:interests, primary_key: false, prefix: "interest") do
+      add :id, :uuid, null: false, primary_key: true
+      add :name, :text
+    end
+
+    # ProfileInterest join table in "profiles" schema
+    create table(:profile_interests, primary_key: false, prefix: "profiles") do
+      add :id, :uuid, null: false, primary_key: true
+
+      add :profile_id,
+          references(:profile,
+            column: :id,
+            name: "profile_interests_profile_id_fkey",
+            type: :uuid,
+            prefix: "profiles"
+          ),
+          null: false
+
+      add :interest_id,
+          references(:interests,
+            column: :id,
+            name: "profile_interests_interest_id_fkey",
+            type: :uuid,
+            prefix: "interest"
+          ),
+          null: false
+    end
+
+    create unique_index(:profile_interests, [:profile_id, :interest_id], prefix: "profiles")
+  end
+
+  def down do
+    drop table(:profile_interests, prefix: "profiles")
+    drop table(:interests, prefix: "interest")
+    execute "DROP SCHEMA IF EXISTS interest"
+  end
+end

--- a/test/cross_schema_many_to_many_test.exs
+++ b/test/cross_schema_many_to_many_test.exs
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: 2019 ash_postgres contributors <https://github.com/ash-project/ash_postgres/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshPostgres.CrossSchemaManyToManyTest do
+  @moduledoc """
+  Regression test for cross-schema many_to_many relationships.
+
+  Test setup (two custom schemas):
+  - Profile lives in "profiles" schema
+  - Interest lives in "interest" schema
+  - ProfileInterest (join table) lives in "profiles" schema
+  """
+  use AshPostgres.RepoCase, async: false
+
+  alias AshPostgres.Test.{Interest, Profile, ProfileInterest}
+
+  test "load many_to_many across custom schemas" do
+    profile = Ash.create!(Profile, %{description: "Test"})
+    interest = Ash.create!(Interest, %{name: "eating the dogs"})
+
+    Ash.create!(ProfileInterest, %{profile_id: profile.id, interest_id: interest.id})
+
+    assert [%{description: "Test"}] = Ash.load!(interest, :profiles).profiles
+  end
+end

--- a/test/support/domain.ex
+++ b/test/support/domain.ex
@@ -72,6 +72,8 @@ defmodule AshPostgres.Test.Domain do
     resource(AshPostgres.Test.Through.Teacher)
     resource(AshPostgres.Test.Through.ClassroomTeacher)
     resource(AshPostgres.Test.Through.Student)
+    resource(AshPostgres.Test.Interest)
+    resource(AshPostgres.Test.ProfileInterest)
   end
 
   authorization do

--- a/test/support/resources/interest.ex
+++ b/test/support/resources/interest.ex
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: 2019 ash_postgres contributors <https://github.com/ash-project/ash_postgres/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshPostgres.Test.Interest do
+  @moduledoc """
+  An interest resource in the "interest" schema (e.g., "sports", "music", "coding").
+
+  Used to test cross-schema many_to_many relationships:
+  - Interest lives in "interest" schema
+  - Profile lives in "profiles" schema
+  - ProfileInterest (join table) lives in "profiles" schema
+  """
+  use Ash.Resource,
+    domain: AshPostgres.Test.Domain,
+    data_layer: AshPostgres.DataLayer
+
+  postgres do
+    table "interests"
+    schema "interest"
+    repo AshPostgres.TestRepo
+  end
+
+  attributes do
+    uuid_primary_key(:id)
+    attribute(:name, :string, public?: true)
+  end
+
+  actions do
+    default_accept(:*)
+    defaults([:read, :destroy, create: :*, update: :*])
+  end
+
+  relationships do
+    many_to_many :profiles, AshPostgres.Test.Profile do
+      public?(true)
+      through(AshPostgres.Test.ProfileInterest)
+      source_attribute_on_join_resource(:interest_id)
+      destination_attribute_on_join_resource(:profile_id)
+    end
+  end
+end

--- a/test/support/resources/profile.ex
+++ b/test/support/resources/profile.ex
@@ -53,5 +53,14 @@ defmodule AshPostgres.Test.Profile do
     belongs_to(:author, AshPostgres.Test.Author) do
       public?(true)
     end
+
+    # Cross-schema many_to_many: Profile (profiles schema) -> Interest (public schema)
+    # through ProfileInterest (profiles schema)
+    many_to_many :interests, AshPostgres.Test.Interest do
+      public?(true)
+      through(AshPostgres.Test.ProfileInterest)
+      source_attribute_on_join_resource(:profile_id)
+      destination_attribute_on_join_resource(:interest_id)
+    end
   end
 end

--- a/test/support/resources/profile_interest.ex
+++ b/test/support/resources/profile_interest.ex
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: 2019 ash_postgres contributors <https://github.com/ash-project/ash_postgres/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshPostgres.Test.ProfileInterest do
+  @moduledoc """
+  A join table in the "profiles" schema linking Profile to Interest.
+
+  This tests cross-schema many_to_many relationships between two custom schemas:
+  - Profile is in "profiles" schema
+  - Interest is in "interest" schema
+  - ProfileInterest (this resource) is in "profiles" schema
+  """
+  use Ash.Resource,
+    domain: AshPostgres.Test.Domain,
+    data_layer: AshPostgres.DataLayer
+
+  postgres do
+    table "profile_interests"
+    schema "profiles"
+    repo AshPostgres.TestRepo
+  end
+
+  attributes do
+    uuid_primary_key(:id)
+  end
+
+  actions do
+    default_accept(:*)
+    defaults([:read, :destroy, create: :*, update: :*])
+  end
+
+  relationships do
+    belongs_to :profile, AshPostgres.Test.Profile do
+      public?(true)
+      allow_nil?(false)
+    end
+
+    belongs_to :interest, AshPostgres.Test.Interest do
+      public?(true)
+      allow_nil?(false)
+    end
+  end
+
+  identities do
+    identity(:unique_profile_interest, [:profile_id, :interest_id])
+  end
+end


### PR DESCRIPTION
Commit 4ddcffec2cda676ebdaeb469375ddee97f5266b2
introduced a bug when loading many_to_many
relationships living in a different schema.
This commit fixes it.


# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

# Context

Loading `many_to_many` relationships across different schemas is broken since commit.
See issue "Wrong schema is being used when querying cross-schema many_to_many relationships" #735 for more details on how to reproduce it.

Integration tests in one of my projects indicated me the error. I then searched for the responsible commit, and IA helped me to find the right fix.

# Concept

- [x] fix the bug reported in #735 
- [x] add a very minimal regression test

## Detail

(from Claude Opus 4.5)

The code in `lateral_join_query` used `through_relationship.source` for schema prefix determination, which returned the wrong resource when the join table lived in a different PostgreSQL schema than the source resource. This caused queries to look for the join table in the wrong schema (e.g., `public.profile_interests` instead of `profiles.profile_interests`).

> Why does through_resource.resource works and through_relationship.source didn’t?

**`through_relationship.source`** refers to the *source resource of the relationship* in the traversal path. For a many-to-many from Profile → Interest through ProfileInterest, the `through_relationship` is the internal relationship used to traverse the path, and its `.source` points back to Profile (the original source), not the join table.

**`through_resource.resource`** is the resource module from the `Ash.Query` struct that was explicitly constructed from the join table resource earlier in the code (in `relationships.ex`). It directly contains the correct resource module (ProfileInterest).

So when Profile is in "profiles" schema and ProfileInterest is also in "profiles" schema:
- `through_relationship.source` → Profile → correct by coincidence
- `through_resource.resource` → ProfileInterest → correct by design

But when Interest is in "interest" schema and you load `interest.profiles`:
- `through_relationship.source` → Interest (wrong - "interest" schema)
- `through_resource.resource` → ProfileInterest (correct - "profiles" schema)

The fix works because `through_resource` was already built from the right resource, so we just use that directly instead of trying to infer it from the relationship's source.

## Tests

I locally runned the tests. 2 are failing, but were already failing before this PR:
```
1) test has_one through relationships student teacher through classroom active_teacher (AshPostgres.Test.ThroughRelationshipsTest)
     test/through_relationships_test.exs:142
     ** (Ash.Error.Unknown) 
     Bread Crumbs:
       > Error returned from: AshPostgres.Test.Through.Teacher.read
       > Error returned from: AshPostgres.Test.Through.Student.read

     Unknown Error

     * Invalid reference retired_at
         at teacher, filter
       (ash 3.24.0) lib/ash/actions/read/read.ex:88: Ash.Actions.Read.run/3
       (ash 3.24.0) lib/ash.ex:2571: Ash.load/3
       (ash 3.24.0) lib/ash.ex:2525: Ash.load/3
       (ash 3.24.0) lib/ash.ex:2427: Ash.load!/3
       test/through_relationships_test.exs:150: AshPostgres.Test.ThroughRelationshipsTest."test has_one through relationships student teacher through classroom active_teacher"/1
       (ex_unit 1.19.5) lib/ex_unit/runner.ex:528: ExUnit.Runner.exec_test/2
       (ex_unit 1.19.5) lib/ex_unit/capture_log.ex:121: ExUnit.CaptureLog.with_log/2
       (ex_unit 1.19.5) lib/ex_unit/runner.ex:477: anonymous fn/3 in ExUnit.Runner.maybe_capture_log/3
       (stdlib 7.3) timer.erl:599: :timer.tc/2
       (ex_unit 1.19.5) lib/ex_unit/runner.ex:450: anonymous fn/6 in ExUnit.Runner.spawn_test_monitor/4
     code: student_with_teacher = Ash.load!(student_1, :teacher)
     stacktrace:
       (ash 3.24.0) lib/ash/actions/read/read.ex:88: Ash.Actions.Read.run/3
       (ash 3.24.0) lib/ash.ex:2571: Ash.load/3
       (ash 3.24.0) lib/ash.ex:2525: Ash.load/3
       (ash 3.24.0) lib/ash.ex:2427: Ash.load!/3
       test/through_relationships_test.exs:150: (test)
       
2) test aggregates on through relationships students know their active teacher (AshPostgres.Test.ThroughRelationshipsTest)
     test/through_relationships_test.exs:237
     ** (Ash.Error.Unknown) 
     Bread Crumbs:
       > Error returned from: AshPostgres.Test.Through.Teacher.read
       > Error returned from: AshPostgres.Test.Through.Student.read

     Unknown Error

     * Invalid reference retired_at
         at teacher, filter
       (ash 3.24.0) lib/ash/actions/read/read.ex:88: Ash.Actions.Read.run/3
       (ash 3.24.0) lib/ash.ex:2571: Ash.load/3
       (ash 3.24.0) lib/ash.ex:2525: Ash.load/3
       (ash 3.24.0) lib/ash.ex:2427: Ash.load!/3
       test/through_relationships_test.exs:248: AshPostgres.Test.ThroughRelationshipsTest."test aggregates on through relationships students know their active teacher"/1
       (ex_unit 1.19.5) lib/ex_unit/runner.ex:528: ExUnit.Runner.exec_test/2
       (ex_unit 1.19.5) lib/ex_unit/capture_log.ex:121: ExUnit.CaptureLog.with_log/2
       (ex_unit 1.19.5) lib/ex_unit/runner.ex:477: anonymous fn/3 in ExUnit.Runner.maybe_capture_log/3
       (stdlib 7.3) timer.erl:599: :timer.tc/2
       (ex_unit 1.19.5) lib/ex_unit/runner.ex:450: anonymous fn/6 in ExUnit.Runner.spawn_test_monitor/4
     code: student_1 = Ash.load!(student_1, [:teacher, :retired_teacher_count])
     stacktrace:
       (ash 3.24.0) lib/ash/actions/read/read.ex:88: Ash.Actions.Read.run/3
       (ash 3.24.0) lib/ash.ex:2571: Ash.load/3
       (ash 3.24.0) lib/ash.ex:2525: Ash.load/3
       (ash 3.24.0) lib/ash.ex:2427: Ash.load!/3
       test/through_relationships_test.exs:248: (test)
```

- [x] the PR adds a regression test which fails if you revert the updated code in `data_layer.ex` (that will ensure this kind of bug should not happen in the future)
- [x] the fix also fixed my project's tests, as intended