### PR TITLE
fix: immutable_expr_error support for newly added required expr

### DIFF
--- a/lib/extensions/immutable_raise_error.ex
+++ b/lib/extensions/immutable_raise_error.ex
@@ -179,6 +179,61 @@ defmodule AshPostgres.Extensions.ImmutableRaiseError do
     end
   end
 
+  def immutable_required_expr(
+        query,
+        %{name: :required!, arguments: [value_expr, attribute]} = required,
+        bindings,
+        embedded?,
+        acc,
+        type
+      ) do
+    pred_embedded? = Map.get(required, :embedded?, false)
+
+    {value_dyn, acc} =
+      AshSql.Expr.dynamic_expr(
+        query,
+        value_expr,
+        bindings,
+        pred_embedded? || embedded?,
+        type,
+        acc
+      )
+
+    resource =
+      Map.get(attribute, :resource) ||
+        raise("attribute must have :resource for ash_required!")
+
+    field =
+      Map.get(attribute, :name) ||
+        Map.get(attribute, "name") ||
+        raise("attribute must have :name for ash_required!")
+
+    payload =
+      %{
+        exception: inspect(Ash.Error.Changes.Required),
+        input: %{field: field, type: :attribute, resource: resource}
+      }
+      |> Jason.encode!()
+
+    case immutable_error_expr_token(query, bindings) do
+      nil ->
+        :error
+
+      row_token ->
+        {:ok,
+         Ecto.Query.dynamic(
+           fragment(
+             "CASE WHEN ? IS NULL THEN ash_raise_error_immutable(?::jsonb, ?, ?) ELSE ? END",
+             ^value_dyn,
+             ^payload,
+             ^value_dyn,
+             ^row_token,
+             ^value_dyn
+           )
+         ), acc}
+    end
+  end
+
   # Encodes an error payload as jsonb using only IMMUTABLE SQL functions.
   #
   # Strategy:

--- a/lib/sql_implementation.ex
+++ b/lib/sql_implementation.ex
@@ -350,16 +350,29 @@ defmodule AshPostgres.SqlImplementation do
       }
       |> Jason.encode!()
 
-    {:ok,
-     Ecto.Query.dynamic(
-       fragment(
-         "CASE WHEN ? IS NULL THEN ash_raise_error(?::jsonb, ?) ELSE ? END",
-         ^value_dyn,
-         ^payload,
-         ^value_dyn,
-         ^value_dyn
-       )
-     ), acc}
+    repo = AshSql.dynamic_repo(resource, AshPostgres.SqlImplementation, query)
+
+    if repo.immutable_expr_error?() do
+      AshPostgres.Extensions.ImmutableRaiseError.immutable_required_expr(
+        query,
+        required,
+        bindings,
+        embedded?,
+        acc,
+        type
+      )
+    else
+      {:ok,
+       Ecto.Query.dynamic(
+         fragment(
+           "CASE WHEN ? IS NULL THEN ash_raise_error(?::jsonb, ?) ELSE ? END",
+           ^value_dyn,
+           ^payload,
+           ^value_dyn,
+           ^value_dyn
+         )
+       ), acc}
+    end
   end
 
   def expr(


### PR DESCRIPTION
## Implements
- Adds support for anyone using `immutable_expr_error` for the required expr added in #707 

Shoutout to @stevebrambilla for helping me track this down.

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
