### PR TITLE
Remove stale timestamp_from_uuid_v7 drop entries

### DIFF
--- a/lib/migration_generator/ash_functions.ex
+++ b/lib/migration_generator/ash_functions.ex
@@ -196,27 +196,27 @@ defmodule AshPostgres.MigrationGenerator.AshFunctions do
   end
 
   def drop(3) do
-    "execute(\"DROP FUNCTION IF EXISTS uuid_generate_v7(), timestamp_from_uuid_v7(uuid), ash_required(ANYCOMPATIBLE, jsonb)\")"
+    "execute(\"DROP FUNCTION IF EXISTS uuid_generate_v7(), ash_required(ANYCOMPATIBLE, jsonb)\")"
   end
 
   def drop(2) do
     """
     #{ash_raise_error()}
 
-    "execute(\"DROP FUNCTION IF EXISTS uuid_generate_v7(), timestamp_from_uuid_v7(uuid), ash_required(ANYCOMPATIBLE, jsonb)\")"
+    "execute(\"DROP FUNCTION IF EXISTS uuid_generate_v7(), ash_required(ANYCOMPATIBLE, jsonb)\")"
     """
   end
 
   def drop(1) do
-    "execute(\"DROP FUNCTION IF EXISTS uuid_generate_v7(), timestamp_from_uuid_v7(uuid), ash_raise_error(jsonb), ash_raise_error(jsonb, ANYCOMPATIBLE), ash_required(ANYCOMPATIBLE, jsonb)\")"
+    "execute(\"DROP FUNCTION IF EXISTS uuid_generate_v7(), ash_raise_error(jsonb), ash_raise_error(jsonb, ANYCOMPATIBLE), ash_required(ANYCOMPATIBLE, jsonb)\")"
   end
 
   def drop(0) do
-    "execute(\"DROP FUNCTION IF EXISTS uuid_generate_v7(), timestamp_from_uuid_v7(uuid), ash_raise_error(jsonb), ash_raise_error(jsonb, ANYCOMPATIBLE), ash_trim_whitespace(text[]), ash_required(ANYCOMPATIBLE, jsonb)\")"
+    "execute(\"DROP FUNCTION IF EXISTS uuid_generate_v7(), ash_raise_error(jsonb), ash_raise_error(jsonb, ANYCOMPATIBLE), ash_trim_whitespace(text[]), ash_required(ANYCOMPATIBLE, jsonb)\")"
   end
 
   def drop(nil) do
-    "execute(\"DROP FUNCTION IF EXISTS uuid_generate_v7(), timestamp_from_uuid_v7(uuid), ash_raise_error(jsonb), ash_raise_error(jsonb, ANYCOMPATIBLE), ash_elixir_and(BOOLEAN, ANYCOMPATIBLE), ash_elixir_and(ANYCOMPATIBLE, ANYCOMPATIBLE), ash_elixir_or(ANYCOMPATIBLE, ANYCOMPATIBLE), ash_elixir_or(BOOLEAN, ANYCOMPATIBLE), ash_trim_whitespace(text[]), ash_required(ANYCOMPATIBLE, jsonb)\")"
+    "execute(\"DROP FUNCTION IF EXISTS uuid_generate_v7(), ash_raise_error(jsonb), ash_raise_error(jsonb, ANYCOMPATIBLE), ash_elixir_and(BOOLEAN, ANYCOMPATIBLE), ash_elixir_and(ANYCOMPATIBLE, ANYCOMPATIBLE), ash_elixir_or(ANYCOMPATIBLE, ANYCOMPATIBLE), ash_elixir_or(BOOLEAN, ANYCOMPATIBLE), ash_trim_whitespace(text[]), ash_required(ANYCOMPATIBLE, jsonb)\")"
   end
 
   defp ash_required do

--- a/priv/resource_snapshots/test_repo/classroom_teachers/20260203115732.json.license
+++ b/priv/resource_snapshots/test_repo/classroom_teachers/20260203115732.json.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2019 ash_postgres contributors <https://github.com/ash-project/ash_postgres/graphs/contributors>
+
+SPDX-License-Identifier: MIT

--- a/priv/resource_snapshots/test_repo/classrooms/20260203115732.json.license
+++ b/priv/resource_snapshots/test_repo/classrooms/20260203115732.json.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2019 ash_postgres contributors <https://github.com/ash-project/ash_postgres/graphs/contributors>
+
+SPDX-License-Identifier: MIT

--- a/priv/resource_snapshots/test_repo/schools/20260203115732.json.license
+++ b/priv/resource_snapshots/test_repo/schools/20260203115732.json.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2019 ash_postgres contributors <https://github.com/ash-project/ash_postgres/graphs/contributors>
+
+SPDX-License-Identifier: MIT

--- a/priv/resource_snapshots/test_repo/students/20260203115732.json.license
+++ b/priv/resource_snapshots/test_repo/students/20260203115732.json.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2019 ash_postgres contributors <https://github.com/ash-project/ash_postgres/graphs/contributors>
+
+SPDX-License-Identifier: MIT

--- a/priv/resource_snapshots/test_repo/teachers/20260203115732.json.license
+++ b/priv/resource_snapshots/test_repo/teachers/20260203115732.json.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2019 ash_postgres contributors <https://github.com/ash-project/ash_postgres/graphs/contributors>
+
+SPDX-License-Identifier: MIT

--- a/priv/test_repo/migrations/20260203115732_migrate_resources70.exs
+++ b/priv/test_repo/migrations/20260203115732_migrate_resources70.exs
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2019 ash_postgres contributors <https://github.com/ash-project/ash_postgres/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
 defmodule AshPostgres.TestRepo.Migrations.MigrateResources70 do
   @moduledoc """
   Updates resources based on their most recent snapshots.

--- a/priv/test_repo/migrations/20260206120932_add_public_to_classrooms.exs
+++ b/priv/test_repo/migrations/20260206120932_add_public_to_classrooms.exs
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2019 ash_postgres contributors <https://github.com/ash-project/ash_postgres/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
 defmodule AshPostgres.TestRepo.Migrations.AddPublicToClassrooms do
   @moduledoc """
   Adds public column to classrooms for through relationship policy testing.

--- a/priv/test_repo/migrations/20260414095619_add_cross_schema_many_to_many_test.exs
+++ b/priv/test_repo/migrations/20260414095619_add_cross_schema_many_to_many_test.exs
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2019 ash_postgres contributors <https://github.com/ash-project/ash_postgres/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
 defmodule AshPostgres.TestRepo.Migrations.AddCrossSchemaM2MTest do
   @moduledoc """
   Migration for cross-schema many_to_many regression test.


### PR DESCRIPTION
Removes `timestamp_from_uuid_v7(uuid)` from older `AshFunctions.drop/1` paths.

It was removed from the install path in `48aaa6d8`, but some drop paths still referenced it.

Also adds the missing REUSE licensing metadata for the newly added test repo snapshots and migrations.

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [X] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [X] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
