### PR TITLE
test: Add reproduction test for error when loading calculation on relationship

### DIFF
--- a/test/calculation_test.exs
+++ b/test/calculation_test.exs
@@ -1810,4 +1810,54 @@ defmodule AshPostgres.CalculationTest do
       assert {:ok, "zach daniel"} = Ash.calculate(author, :non_field_full_name)
     end
   end
+
+  describe "referencing related resource aggregate in calculation with policies" do
+    test "can load a calculation that references an aggregate on a related resource when authorized" do
+      org =
+        AshPostgres.Test.Organization
+        |> Ash.Changeset.for_create(:create, %{name: "The Org"})
+        |> Ash.create!()
+
+      user =
+        User
+        |> Ash.Changeset.for_create(:create, %{})
+        |> Ash.Changeset.manage_relationship(:organization, org, type: :append_and_remove)
+        |> Ash.create!()
+
+      post =
+        Post
+        |> Ash.Changeset.for_create(:create, %{title: "Test Post"})
+        |> Ash.Changeset.manage_relationship(:organization, org, type: :append_and_remove)
+        |> Ash.create!()
+
+      comment =
+        Comment
+        |> Ash.Changeset.for_create(:create, %{title: "Test Comment"})
+        |> Ash.Changeset.manage_relationship(:post, post, type: :append_and_remove)
+        |> Ash.create!()
+
+      Comment
+      |> Ash.Changeset.for_create(:create, %{title: "Another Comment"})
+      |> Ash.Changeset.manage_relationship(:post, post, type: :append_and_remove)
+      |> Ash.create!()
+
+      # Here without authorization, the calculation is loaded succesfully
+      result =
+        Comment
+        |> Ash.Query.filter(id == ^comment.id)
+        |> Ash.Query.load(:post_count_of_comments)
+        |> Ash.read_one!(actor: user, authorize?: false)
+
+      assert result.post_count_of_comments == 2
+
+      # With authorization enabled the query fails.
+      result =
+        Comment
+        |> Ash.Query.filter(id == ^comment.id)
+        |> Ash.Query.load(:post_count_of_comments)
+        |> Ash.read_one!(actor: user)
+
+      assert result.post_count_of_comments == 2
+    end
+  end
 end

--- a/test/support/resources/comment.ex
+++ b/test/support/resources/comment.ex
@@ -153,6 +153,12 @@ defmodule AshPostgres.Test.Comment do
     end)
 
     calculate(:has_rating, :boolean, expr(not is_nil(latest_rating_score)))
+
+    calculate(
+      :post_count_of_comments,
+      :integer,
+      expr(post.count_of_comments)
+    )
   end
 
   relationships do


### PR DESCRIPTION
I ran into a bug in ash_postgres, or maybe ash_sql I'm not 100% sure. 

The issue seems to be when loading a calculcation on a resource which references an aggregate on a related resource. 

For example:
```elixir
defmodule Post do
  aggregates do
    count(:count_of_comments, :comments)
  end

  relationships do
    has_many(:comments, Comment, public?: true)
  end
end

defmodule Comment do
  policies do
    bypass action_type(:read) do
      # This seems to give issues. Whenever the policy involves a data-layer query the error is raised.
      authorize_if(relates_to_actor_via([:post, :organization, :users]))

      # Something like this also throws the error:
      authorize_if expr(not is_nil(post.id))
    end
  end

  calculations do
    calculate(
      :post_count_of_comments,
      :integer,
      expr(post.count_of_comments)
    )
  end

  belongs_to(:post, Post) do
      public?(true)
  end
end
```

So it seems that the datalayer queries introduced by the authorization policies cause errors while loading the related resource calculation. 

### Reproduction test
run with:
```
mix test test/calculation_test.exs:1822
```


See initial report: https://discord.com/channels/711271361523351632/1496159794225090630

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
