### PR TITLE
fix: handle base filter index rewrite detection

### DIFF
--- a/lib/migration_generator/migration_generator.ex
+++ b/lib/migration_generator/migration_generator.ex
@@ -1891,6 +1891,13 @@ defmodule AshPostgres.MigrationGenerator do
   end
 
   defp after?(
+         %Operation.RemoveCustomIndex{table: table, schema: schema},
+         %Operation.AddCustomIndex{table: table, schema: schema}
+       ) do
+    false
+  end
+
+  defp after?(
          %Operation.RenameAttribute{
            old_attribute: %{source: source},
            table: table,

--- a/lib/migration_generator/migration_generator.ex
+++ b/lib/migration_generator/migration_generator.ex
@@ -2308,7 +2308,8 @@ defmodule AshPostgres.MigrationGenerator do
     {pkey_operations, attribute_operations} =
       pkey_operations(snapshot, old_snapshot, attribute_operations, opts)
 
-    rewrite_all_identities? = changing_multitenancy_affects_identities?(snapshot, old_snapshot)
+    multitenancy_changed? =
+      Map.delete(snapshot.multitenancy, :global) != Map.delete(old_snapshot.multitenancy, :global)
 
     custom_statements_to_add =
       snapshot.custom_statements
@@ -2343,9 +2344,9 @@ defmodule AshPostgres.MigrationGenerator do
 
     custom_indexes_to_add =
       Enum.filter(snapshot.custom_indexes, fn index ->
-        (rewrite_all_identities? && !index.all_tenants?) ||
+        rewrite_for_multitenancy_change?(index, multitenancy_changed?) ||
           !Enum.find(old_snapshot.custom_indexes, fn old_custom_index ->
-            indexes_match?(snapshot.table, old_custom_index, index)
+            indexes_match?(old_custom_index, old_snapshot, index, snapshot)
           end)
       end)
       |> Enum.map(fn custom_index ->
@@ -2406,9 +2407,9 @@ defmodule AshPostgres.MigrationGenerator do
 
     custom_indexes_to_remove =
       Enum.filter(old_snapshot.custom_indexes, fn old_custom_index ->
-        (rewrite_all_identities? && !old_custom_index.all_tenants?) ||
+        rewrite_for_multitenancy_change?(old_custom_index, multitenancy_changed?) ||
           !Enum.find(snapshot.custom_indexes, fn index ->
-            indexes_match?(snapshot.table, old_custom_index, index)
+            indexes_match?(old_custom_index, old_snapshot, index, snapshot)
           end)
       end)
       |> Enum.map(fn custom_index ->
@@ -2422,20 +2423,10 @@ defmodule AshPostgres.MigrationGenerator do
       end)
 
     unique_indexes_to_remove =
-      if rewrite_all_identities? do
-        Enum.reject(old_snapshot.identities, & &1.all_tenants?)
-      else
-        Enum.reject(old_snapshot.identities, fn old_identity ->
-          Enum.find(snapshot.identities, fn identity ->
-            identity.name == old_identity.name &&
-              old_identity.keys == identity.keys &&
-              old_identity.base_filter == identity.base_filter &&
-              old_identity.all_tenants? == identity.all_tenants? &&
-              old_identity.nils_distinct? == identity.nils_distinct? &&
-              old_identity.where == identity.where
-          end)
-        end)
-      end
+      Enum.filter(old_snapshot.identities, fn old_identity ->
+        rewrite_for_multitenancy_change?(old_identity, multitenancy_changed?) ||
+          !Enum.find(snapshot.identities, &identities_match?(&1, old_identity))
+      end)
       |> Enum.map(fn identity ->
         %Operation.RemoveUniqueIndex{
           identity: identity,
@@ -2445,30 +2436,17 @@ defmodule AshPostgres.MigrationGenerator do
       end)
 
     unique_indexes_to_rename =
-      if rewrite_all_identities? do
-        snapshot.identities
-        |> Enum.filter(& &1.all_tenants?)
-        |> Enum.map(fn identity ->
-          Enum.find_value(old_snapshot.identities, fn old_identity ->
-            if old_identity.name == identity.name &&
-                 old_identity.index_name != identity.index_name do
-              {old_identity, identity}
-            end
-          end)
+      snapshot.identities
+      |> Enum.reject(&rewrite_for_multitenancy_change?(&1, multitenancy_changed?))
+      |> Enum.map(fn identity ->
+        Enum.find_value(old_snapshot.identities, fn old_identity ->
+          if identities_match?(old_identity, identity) &&
+               old_identity.index_name != identity.index_name do
+            {old_identity, identity}
+          end
         end)
-        |> Enum.filter(& &1)
-      else
-        snapshot.identities
-        |> Enum.map(fn identity ->
-          Enum.find_value(old_snapshot.identities, fn old_identity ->
-            if old_identity.name == identity.name &&
-                 old_identity.index_name != identity.index_name do
-              {old_identity, identity}
-            end
-          end)
-        end)
-        |> Enum.filter(& &1)
-      end
+      end)
+      |> Enum.filter(& &1)
       |> Enum.map(fn {old_identity, new_identity} ->
         %Operation.RenameUniqueIndex{
           old_identity: old_identity,
@@ -2479,34 +2457,10 @@ defmodule AshPostgres.MigrationGenerator do
       end)
 
     unique_indexes_to_add =
-      if rewrite_all_identities? do
-        snapshot.identities
-        |> Enum.reject(fn identity ->
-          if identity.all_tenants? do
-            Enum.find(old_snapshot.identities, fn old_identity ->
-              old_identity.name == identity.name &&
-                old_identity.keys == identity.keys &&
-                old_identity.base_filter == identity.base_filter &&
-                old_identity.all_tenants? == identity.all_tenants? &&
-                old_identity.nils_distinct? == identity.nils_distinct? &&
-                old_identity.where == identity.where
-            end)
-          else
-            false
-          end
-        end)
-      else
-        Enum.reject(snapshot.identities, fn identity ->
-          Enum.find(old_snapshot.identities, fn old_identity ->
-            old_identity.name == identity.name &&
-              old_identity.keys == identity.keys &&
-              old_identity.base_filter == identity.base_filter &&
-              old_identity.all_tenants? == identity.all_tenants? &&
-              old_identity.nils_distinct? == identity.nils_distinct? &&
-              old_identity.where == identity.where
-          end)
-        end)
-      end
+      Enum.filter(snapshot.identities, fn identity ->
+        rewrite_for_multitenancy_change?(identity, multitenancy_changed?) ||
+          !Enum.find(old_snapshot.identities, &identities_match?(&1, identity))
+      end)
       |> Enum.map(fn identity ->
         {insert_after_attribute_source, _best_index} =
           identity.keys
@@ -2593,24 +2547,28 @@ defmodule AshPostgres.MigrationGenerator do
     |> Enum.map(&Map.put(&1, :old_multitenancy, old_snapshot.multitenancy))
   end
 
-  defp indexes_match?(table, left, right) do
-    left =
-      left
-      |> Map.update!(:fields, fn fields ->
-        Enum.map(fields, &to_string/1)
-      end)
-      |> add_custom_index_name(table)
-      |> Map.delete(:error_fields)
+  defp indexes_match?(left_index, left_snapshot, right_index, right_snapshot) do
+    custom_index_comparison_key(left_index, left_snapshot) ==
+      custom_index_comparison_key(right_index, right_snapshot)
+  end
 
-    right =
-      right
-      |> Map.update!(:fields, fn fields ->
-        Enum.map(fields, &to_string/1)
-      end)
-      |> add_custom_index_name(table)
-      |> Map.delete(:error_fields)
+  defp custom_index_comparison_key(index, snapshot) do
+    index
+    |> Map.update!(:fields, fn fields ->
+      Enum.map(fields, &to_string/1)
+    end)
+    |> add_custom_index_name(snapshot.table)
+    |> Map.put(:where, {snapshot.base_filter, index.where})
+    |> Map.delete(:error_fields)
+  end
 
-    left == right
+  @identity_match_keys [:name, :keys, :base_filter, :all_tenants?, :nils_distinct?, :where]
+  defp identities_match?(left, right) do
+    Map.take(left, @identity_match_keys) == Map.take(right, @identity_match_keys)
+  end
+
+  defp rewrite_for_multitenancy_change?(index, multitenancy_changed?) do
+    !index.all_tenants? && multitenancy_changed?
   end
 
   defp add_custom_index_name(custom_index, table) do
@@ -3138,11 +3096,6 @@ defmodule AshPostgres.MigrationGenerator do
 
   defp add_schema(attribute, _) do
     attribute
-  end
-
-  def changing_multitenancy_affects_identities?(snapshot, old_snapshot) do
-    Map.delete(snapshot.multitenancy, :global) != Map.delete(old_snapshot.multitenancy, :global) ||
-      snapshot.base_filter != old_snapshot.base_filter
   end
 
   def has_reference?(multitenancy, attribute) do

--- a/test/migration_generator_test.exs
+++ b/test/migration_generator_test.exs
@@ -2710,6 +2710,457 @@ defmodule AshPostgres.MigrationGeneratorTest do
                ~S{create unique_index(:users, [:name], name: "users_unique_name_index")}
     end
 
+    test "when base_filter changes, `all_tenants?: true` identity is dropped and recreated",
+         %{snapshot_path: snapshot_path, migration_path: migration_path} do
+      defresource Org, "orgs" do
+        attributes do
+          uuid_primary_key(:id, writable?: true)
+        end
+
+        multitenancy do
+          strategy(:attribute)
+          attribute(:id)
+        end
+      end
+
+      defresource User, "users" do
+        attributes do
+          uuid_primary_key(:id, writable?: true)
+          attribute(:name, :string, public?: true)
+          attribute(:org_id, :uuid, public?: true)
+          attribute(:archived, :boolean, public?: true, default: false)
+        end
+
+        multitenancy do
+          strategy(:attribute)
+          attribute(:org_id)
+        end
+
+        identities do
+          identity(:unique_name, [:name], all_tenants?: true)
+        end
+
+        resource do
+          base_filter(expr(archived == false))
+        end
+
+        postgres do
+          base_filter_sql "archived = false"
+        end
+
+        relationships do
+          belongs_to(:org, Org) do
+            public?(true)
+          end
+        end
+      end
+
+      defdomain([Org, User])
+
+      AshPostgres.MigrationGenerator.generate(Domain,
+        snapshot_path: snapshot_path,
+        migration_path: migration_path,
+        quiet: true,
+        format: false,
+        auto_name: true
+      )
+
+      defresource User, "users" do
+        attributes do
+          uuid_primary_key(:id, writable?: true)
+          attribute(:name, :string, public?: true)
+          attribute(:org_id, :uuid, public?: true)
+          attribute(:archived, :boolean, public?: true, default: false)
+          attribute(:hidden, :boolean, public?: true, default: false)
+        end
+
+        multitenancy do
+          strategy(:attribute)
+          attribute(:org_id)
+        end
+
+        identities do
+          identity(:unique_name, [:name], all_tenants?: true)
+        end
+
+        resource do
+          base_filter(expr(archived == false and hidden == false))
+        end
+
+        postgres do
+          base_filter_sql "archived = false AND hidden = false"
+        end
+
+        relationships do
+          belongs_to(:org, Org) do
+            public?(true)
+          end
+        end
+      end
+
+      defdomain([Org, User])
+
+      AshPostgres.MigrationGenerator.generate(Domain,
+        snapshot_path: snapshot_path,
+        migration_path: migration_path,
+        quiet: true,
+        format: false,
+        auto_name: true
+      )
+
+      [_first_file, second_file] =
+        Path.wildcard("#{migration_path}/**/*_migrate_resources*.exs")
+        |> Enum.reject(&String.contains?(&1, "extensions"))
+        |> Enum.sort()
+
+      second_contents = File.read!(second_file)
+
+      assert [up_code, _down_code] = String.split(second_contents, "def down do")
+
+      assert up_code =~
+               ~S{drop_if_exists unique_index(:users, [:name], name: "users_unique_name_index")}
+
+      assert up_code =~
+               ~S{create unique_index(:users, [:name], where: "(archived = false AND hidden = false)"}
+    end
+
+    test "when base_filter changes, `all_tenants?: true` custom index is dropped and recreated",
+         %{snapshot_path: snapshot_path, migration_path: migration_path} do
+      defresource Org, "orgs" do
+        attributes do
+          uuid_primary_key(:id, writable?: true)
+        end
+
+        multitenancy do
+          strategy(:attribute)
+          attribute(:id)
+        end
+      end
+
+      defresource User, "users" do
+        attributes do
+          uuid_primary_key(:id, writable?: true)
+          attribute(:name, :string, public?: true)
+          attribute(:org_id, :uuid, public?: true)
+          attribute(:archived, :boolean, public?: true, default: false)
+        end
+
+        multitenancy do
+          strategy(:attribute)
+          attribute(:org_id)
+        end
+
+        resource do
+          base_filter(expr(archived == false))
+        end
+
+        postgres do
+          base_filter_sql "archived = false"
+
+          custom_indexes do
+            index([:name], all_tenants?: true, unique: true, name: "users_active_name_index")
+          end
+        end
+
+        relationships do
+          belongs_to(:org, Org) do
+            public?(true)
+          end
+        end
+      end
+
+      defdomain([Org, User])
+
+      AshPostgres.MigrationGenerator.generate(Domain,
+        snapshot_path: snapshot_path,
+        migration_path: migration_path,
+        quiet: true,
+        format: false,
+        auto_name: true
+      )
+
+      defresource User, "users" do
+        attributes do
+          uuid_primary_key(:id, writable?: true)
+          attribute(:name, :string, public?: true)
+          attribute(:org_id, :uuid, public?: true)
+          attribute(:archived, :boolean, public?: true, default: false)
+          attribute(:hidden, :boolean, public?: true, default: false)
+        end
+
+        multitenancy do
+          strategy(:attribute)
+          attribute(:org_id)
+        end
+
+        resource do
+          base_filter(expr(archived == false and hidden == false))
+        end
+
+        postgres do
+          base_filter_sql "archived = false AND hidden = false"
+
+          custom_indexes do
+            index([:name], all_tenants?: true, unique: true, name: "users_active_name_index")
+          end
+        end
+
+        relationships do
+          belongs_to(:org, Org) do
+            public?(true)
+          end
+        end
+      end
+
+      defdomain([Org, User])
+
+      AshPostgres.MigrationGenerator.generate(Domain,
+        snapshot_path: snapshot_path,
+        migration_path: migration_path,
+        quiet: true,
+        format: false,
+        auto_name: true
+      )
+
+      [_first_file, second_file] =
+        Path.wildcard("#{migration_path}/**/*_migrate_resources*.exs")
+        |> Enum.reject(&String.contains?(&1, "extensions"))
+        |> Enum.sort()
+
+      second_contents = File.read!(second_file)
+
+      assert [up_code, _down_code] = String.split(second_contents, "def down do")
+
+      assert up_code =~
+               ~S{drop_if_exists index(:users, [:name], name: "users_active_name_index")}
+
+      assert up_code =~
+               ~S{create index(:users, [:name], name: "users_active_name_index", unique: true, where: "archived = false AND hidden = false")}
+    end
+
+    test "when multitenancy changes, `all_tenants?: true` indexes are not rewritten",
+         %{snapshot_path: snapshot_path, migration_path: migration_path} do
+      defresource Org, "orgs" do
+        attributes do
+          uuid_primary_key(:id, writable?: true)
+        end
+      end
+
+      defresource User, "users" do
+        attributes do
+          uuid_primary_key(:id, writable?: true)
+          attribute(:name, :string, public?: true)
+          attribute(:email, :string, public?: true)
+          attribute(:org_id, :uuid, public?: true)
+          attribute(:account_id, :uuid, public?: true)
+        end
+
+        multitenancy do
+          strategy(:attribute)
+          attribute(:org_id)
+        end
+
+        identities do
+          identity(:scoped_name, [:name])
+          identity(:global_email, [:email], all_tenants?: true)
+        end
+
+        postgres do
+          custom_indexes do
+            index([:email], all_tenants?: true, name: "users_global_email_index")
+          end
+        end
+
+        relationships do
+          belongs_to(:org, Org) do
+            public?(true)
+          end
+        end
+      end
+
+      defdomain([Org, User])
+
+      AshPostgres.MigrationGenerator.generate(Domain,
+        snapshot_path: snapshot_path,
+        migration_path: migration_path,
+        quiet: true,
+        format: false,
+        auto_name: true
+      )
+
+      defresource User, "users" do
+        attributes do
+          uuid_primary_key(:id, writable?: true)
+          attribute(:name, :string, public?: true)
+          attribute(:email, :string, public?: true)
+          attribute(:org_id, :uuid, public?: true)
+          attribute(:account_id, :uuid, public?: true)
+        end
+
+        multitenancy do
+          strategy(:attribute)
+          attribute(:account_id)
+        end
+
+        identities do
+          identity(:scoped_name, [:name])
+          identity(:global_email, [:email], all_tenants?: true)
+        end
+
+        postgres do
+          custom_indexes do
+            index([:email], all_tenants?: true, name: "users_global_email_index")
+          end
+        end
+
+        relationships do
+          belongs_to(:org, Org) do
+            public?(true)
+          end
+        end
+      end
+
+      defdomain([Org, User])
+
+      AshPostgres.MigrationGenerator.generate(Domain,
+        snapshot_path: snapshot_path,
+        migration_path: migration_path,
+        quiet: true,
+        format: false,
+        auto_name: true
+      )
+
+      [_first_file, second_file] =
+        Path.wildcard("#{migration_path}/**/*_migrate_resources*.exs")
+        |> Enum.reject(&String.contains?(&1, "extensions"))
+        |> Enum.sort()
+
+      second_contents = File.read!(second_file)
+
+      assert second_contents =~
+               ~S{drop_if_exists unique_index(:users, [:org_id, :name], name: "users_scoped_name_index")}
+
+      refute second_contents =~ ~S{users_global_email_index}
+      refute second_contents =~ ~S{users_global_email_unique_index}
+    end
+
+    test "when base_filter and identity index_name change together, only drop and create are emitted",
+         %{snapshot_path: snapshot_path, migration_path: migration_path} do
+      defresource Org, "orgs" do
+        attributes do
+          uuid_primary_key(:id, writable?: true)
+        end
+
+        multitenancy do
+          strategy(:attribute)
+          attribute(:id)
+        end
+      end
+
+      defresource User, "users" do
+        attributes do
+          uuid_primary_key(:id, writable?: true)
+          attribute(:name, :string, public?: true)
+          attribute(:org_id, :uuid, public?: true)
+          attribute(:archived, :boolean, public?: true, default: false)
+        end
+
+        multitenancy do
+          strategy(:attribute)
+          attribute(:org_id)
+        end
+
+        identities do
+          identity(:unique_name, [:name], all_tenants?: true)
+        end
+
+        resource do
+          base_filter(expr(archived == false))
+        end
+
+        postgres do
+          base_filter_sql "archived = false"
+        end
+
+        relationships do
+          belongs_to(:org, Org) do
+            public?(true)
+          end
+        end
+      end
+
+      defdomain([Org, User])
+
+      AshPostgres.MigrationGenerator.generate(Domain,
+        snapshot_path: snapshot_path,
+        migration_path: migration_path,
+        quiet: true,
+        format: false,
+        auto_name: true
+      )
+
+      defresource User, "users" do
+        attributes do
+          uuid_primary_key(:id, writable?: true)
+          attribute(:name, :string, public?: true)
+          attribute(:org_id, :uuid, public?: true)
+          attribute(:archived, :boolean, public?: true, default: false)
+          attribute(:hidden, :boolean, public?: true, default: false)
+        end
+
+        multitenancy do
+          strategy(:attribute)
+          attribute(:org_id)
+        end
+
+        identities do
+          identity(:unique_name, [:name], all_tenants?: true)
+        end
+
+        resource do
+          base_filter(expr(archived == false and hidden == false))
+        end
+
+        postgres do
+          base_filter_sql "archived = false AND hidden = false"
+          identity_index_names(unique_name: "renamed_users_unique_name_index")
+        end
+
+        relationships do
+          belongs_to(:org, Org) do
+            public?(true)
+          end
+        end
+      end
+
+      defdomain([Org, User])
+
+      AshPostgres.MigrationGenerator.generate(Domain,
+        snapshot_path: snapshot_path,
+        migration_path: migration_path,
+        quiet: true,
+        format: false,
+        auto_name: true
+      )
+
+      [_first_file, second_file] =
+        Path.wildcard("#{migration_path}/**/*_migrate_resources*.exs")
+        |> Enum.reject(&String.contains?(&1, "extensions"))
+        |> Enum.sort()
+
+      second_contents = File.read!(second_file)
+
+      assert [up_code, _down_code] = String.split(second_contents, "def down do")
+
+      assert up_code =~
+               ~S{drop_if_exists unique_index(:users, [:name], name: "users_unique_name_index")}
+
+      assert up_code =~
+               ~S{create unique_index(:users, [:name], where: "(archived = false AND hidden = false)", name: "renamed_users_unique_name_index")}
+
+      refute up_code =~ "ALTER INDEX"
+    end
+
     test "when modified, the foreign key is dropped before modification", %{
       snapshot_path: snapshot_path,
       migration_path: migration_path

--- a/test/migration_generator_test.exs
+++ b/test/migration_generator_test.exs
@@ -2936,6 +2936,20 @@ defmodule AshPostgres.MigrationGeneratorTest do
 
       assert up_code =~
                ~S{create index(:users, [:name], name: "users_active_name_index", unique: true, where: "archived = false AND hidden = false")}
+
+      {drop_index, _drop_length} =
+        :binary.match(
+          up_code,
+          ~S{drop_if_exists index(:users, [:name], name: "users_active_name_index")}
+        )
+
+      {create_index, _create_length} =
+        :binary.match(
+          up_code,
+          ~S{create index(:users, [:name], name: "users_active_name_index", unique: true, where: "archived = false AND hidden = false")}
+        )
+
+      assert drop_index < create_index
     end
 
     test "when multitenancy changes, `all_tenants?: true` indexes are not rewritten",


### PR DESCRIPTION
# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

## Summary
- compare custom indexes using snapshot context so `all_tenants?: true` indexes are rewritten when `base_filter` changes
