### PR TITLE
Resource generator: many-to-many, views, no-PK tables, and prompt UX

### DIFF
--- a/lib/mix/tasks/ash_postgres.gen.resources.ex
+++ b/lib/mix/tasks/ash_postgres.gen.resources.ex
@@ -35,6 +35,7 @@ if Code.ensure_loaded?(Igniter) do
     - `no-migrations` - Do not generate snapshots & migrations for the resources. Defaults to `false`.
     - `skip-unknown` - Skip any attributes with types that we don't have a corresponding Elixir type for, and relationships that we can't assume the name of.
     - `fragments` - Generate attributes and relationships in a separate fragment file. This allows the fragment to be regenerated without affecting user customizations in the main resource file. Defaults to `false`.
+    - `skip-many-to-many` - Do not generate `many_to_many` relationships for detected join tables. `has_many` relationships to join tables are still generated. Defaults to `false`.
 
     ## Tables
 
@@ -63,7 +64,8 @@ if Code.ensure_loaded?(Igniter) do
           migrations: :boolean,
           snapshots_only: :boolean,
           domain: :keep,
-          fragments: :boolean
+          fragments: :boolean,
+          skip_many_to_many: :boolean
         ],
         aliases: [
           t: :tables,
@@ -77,7 +79,8 @@ if Code.ensure_loaded?(Igniter) do
           default_actions: true,
           migrations: true,
           public: true,
-          fragments: false
+          fragments: false,
+          skip_many_to_many: false
         ]
       }
     end

--- a/lib/mix/tasks/ash_postgres.gen.resources.ex
+++ b/lib/mix/tasks/ash_postgres.gen.resources.ex
@@ -36,6 +36,7 @@ if Code.ensure_loaded?(Igniter) do
     - `skip-unknown` - Skip any attributes with types that we don't have a corresponding Elixir type for, and relationships that we can't assume the name of.
     - `fragments` - Generate attributes and relationships in a separate fragment file. This allows the fragment to be regenerated without affecting user customizations in the main resource file. Defaults to `false`.
     - `skip-many-to-many` - Do not generate `many_to_many` relationships for detected join tables. `has_many` relationships to join tables are still generated. Defaults to `false`.
+    - `include-views` - Include PostgreSQL VIEWs and MATERIALIZED VIEWs alongside base tables. Generated resources use `migrate? false` and default to `[:read]` actions only. For materialized views, unique indexes are surfaced as Ash identities. Defaults to `false`.
 
     ## Tables
 
@@ -65,7 +66,8 @@ if Code.ensure_loaded?(Igniter) do
           snapshots_only: :boolean,
           domain: :keep,
           fragments: :boolean,
-          skip_many_to_many: :boolean
+          skip_many_to_many: :boolean,
+          include_views: :boolean
         ],
         aliases: [
           t: :tables,
@@ -80,7 +82,8 @@ if Code.ensure_loaded?(Igniter) do
           migrations: true,
           public: true,
           fragments: false,
-          skip_many_to_many: false
+          skip_many_to_many: false,
+          include_views: false
         ]
       }
     end

--- a/lib/resource_generator/resource_generator.ex
+++ b/lib/resource_generator/resource_generator.ex
@@ -45,7 +45,8 @@ if Code.ensure_loaded?(Igniter) do
           &Spec.tables(&1,
             skip_tables: opts[:skip_tables],
             tables: opts[:tables],
-            skip_unknown: opts[:skip_unknown]
+            skip_unknown: opts[:skip_unknown],
+            include_views: opts[:include_views]
           )
         )
         |> Enum.map(fn %{table_name: table} = spec ->
@@ -107,11 +108,6 @@ if Code.ensure_loaded?(Igniter) do
            domain,
            opts
          ) do
-      no_migrate_flag =
-        if opts[:no_migrations] do
-          "migrate? false"
-        end
-
       resource =
         """
         use Ash.Resource,
@@ -125,7 +121,7 @@ if Code.ensure_loaded?(Igniter) do
           table #{inspect(table_spec.table_name)}
           repo #{inspect(table_spec.repo)}
           #{schema_option(table_spec)}
-          #{no_migrate_flag}
+          #{migrate_option(table_spec, opts)}
           #{references(table_spec, opts[:no_migrations])}
           #{custom_indexes(table_spec, opts[:no_migrations])}
           #{check_constraints(table_spec, opts[:no_migrations])}
@@ -182,12 +178,6 @@ if Code.ensure_loaded?(Igniter) do
         # Only create/update the fragment file
         Igniter.Project.Module.create_module(igniter, fragment_module, fragment_content)
       else
-        # Create both resource and fragment
-        no_migrate_flag =
-          if opts[:no_migrations] do
-            "migrate? false"
-          end
-
         resource_content =
           """
           use Ash.Resource,
@@ -202,7 +192,7 @@ if Code.ensure_loaded?(Igniter) do
             table #{inspect(table_spec.table_name)}
             repo #{inspect(table_spec.repo)}
             #{schema_option(table_spec)}
-            #{no_migrate_flag}
+            #{migrate_option(table_spec, opts)}
             #{references(table_spec, opts[:no_migrations])}
             #{custom_indexes(table_spec, opts[:no_migrations])}
             #{check_constraints(table_spec, opts[:no_migrations])}
@@ -306,6 +296,14 @@ if Code.ensure_loaded?(Igniter) do
       Enum.all?(attributes, &(not &1.primary_key?))
     end
 
+    defp view?(%AshPostgres.ResourceGenerator.Spec{kind: kind}),
+      do: kind in [:view, :materialized_view]
+
+    defp view_kind_label(%AshPostgres.ResourceGenerator.Spec{kind: :view}), do: "VIEW"
+
+    defp view_kind_label(%AshPostgres.ResourceGenerator.Spec{kind: :materialized_view}),
+      do: "MATERIALIZED VIEW"
+
     defp resource_block(table_spec) do
       if no_primary_key?(table_spec) do
         """
@@ -322,6 +320,15 @@ if Code.ensure_loaded?(Igniter) do
 
     defp default_actions(opts, table_spec) do
       cond do
+        view?(table_spec) ->
+          """
+          actions do
+            # WARNING: Generated from a PostgreSQL #{view_kind_label(table_spec)}.
+            # Views are read-only; only the :read default action is safe.
+            defaults [:read]
+          end
+          """
+
         no_primary_key?(table_spec) ->
           """
           actions do
@@ -337,6 +344,24 @@ if Code.ensure_loaded?(Igniter) do
             defaults [:read, :destroy, create: :*, update: :*]
           end
           """
+
+        true ->
+          ""
+      end
+    end
+
+    defp migrate_option(table_spec, opts) do
+      cond do
+        view?(table_spec) ->
+          """
+          # NOTE: Source is a PostgreSQL #{view_kind_label(table_spec)}, not a base table.
+          # migrate? false prevents Ash from trying to manage its schema.
+          # TODO: Migrations need to be handled manually for views.
+          migrate? false
+          """
+
+        opts[:no_migrations] ->
+          "migrate? false"
 
         true ->
           ""

--- a/lib/resource_generator/resource_generator.ex
+++ b/lib/resource_generator/resource_generator.ex
@@ -550,7 +550,7 @@ if Code.ensure_loaded?(Igniter) do
           |> add_destination_attribute(rel, "id")
           |> add_source_attribute(rel, "#{rel.name}_id")
           |> add_allow_nil(rel)
-          |> add_primary_key(attribute.primary_key?)
+          |> add_primary_key(attribute)
           |> add_attribute_type(attribute)
           |> add_filter(rel)
           |> add_public(opts)

--- a/lib/resource_generator/resource_generator.ex
+++ b/lib/resource_generator/resource_generator.ex
@@ -503,19 +503,34 @@ if Code.ensure_loaded?(Igniter) do
       end
     end
 
+    defp relationship_options(_spec, %{type: :many_to_many} = rel, opts) do
+      default_source_on_join = module_to_id_string(rel.source)
+      default_dest_on_join = module_to_id_string(rel.destination)
+
+      ""
+      |> add_through(rel)
+      |> add_join_relationship(rel)
+      |> add_source_attribute_on_join_resource(rel, default_source_on_join)
+      |> add_destination_attribute_on_join_resource(rel, default_dest_on_join)
+      |> add_public(opts)
+    end
+
     defp relationship_options(_spec, rel, opts) do
-      default_destination_attribute =
-        rel.source
-        |> Module.split()
-        |> List.last()
-        |> Macro.underscore()
-        |> Kernel.<>("_id")
+      default_destination_attribute = module_to_id_string(rel.source)
 
       ""
       |> add_destination_attribute(rel, default_destination_attribute)
       |> add_source_attribute(rel, "id")
       |> add_filter(rel)
       |> add_public(opts)
+    end
+
+    defp module_to_id_string(module) do
+      module
+      |> Module.split()
+      |> List.last()
+      |> Macro.underscore()
+      |> Kernel.<>("_id")
     end
 
     defp add_filter(str, %{match_with: []}), do: str
@@ -527,6 +542,30 @@ if Code.ensure_loaded?(Igniter) do
         end)
 
       "#{str}\n filter expr(#{filter})"
+    end
+
+    defp add_through(str, %{through: through}) do
+      "#{str}\n through #{inspect(through)}"
+    end
+
+    defp add_join_relationship(str, %{join_relationship: name}) do
+      "#{str}\n join_relationship :#{name}"
+    end
+
+    defp add_source_attribute_on_join_resource(str, rel, default) do
+      if rel.source_attribute_on_join_resource == default do
+        str
+      else
+        "#{str}\n source_attribute_on_join_resource :#{rel.source_attribute_on_join_resource}"
+      end
+    end
+
+    defp add_destination_attribute_on_join_resource(str, rel, default) do
+      if rel.destination_attribute_on_join_resource == default do
+        str
+      else
+        "#{str}\n destination_attribute_on_join_resource :#{rel.destination_attribute_on_join_resource}"
+      end
     end
 
     defp add_attribute_type(str, %{attr_type: :uuid}), do: str

--- a/lib/resource_generator/resource_generator.ex
+++ b/lib/resource_generator/resource_generator.ex
@@ -118,7 +118,8 @@ if Code.ensure_loaded?(Igniter) do
           domain: #{inspect(domain)},
           data_layer: AshPostgres.DataLayer
 
-        #{default_actions(opts)}
+        #{resource_block(table_spec)}
+        #{default_actions(opts, table_spec)}
 
         postgres do
           table #{inspect(table_spec.table_name)}
@@ -194,7 +195,8 @@ if Code.ensure_loaded?(Igniter) do
             data_layer: AshPostgres.DataLayer,
             fragments: [#{inspect(fragment_module)}]
 
-          #{default_actions(opts)}
+          #{resource_block(table_spec)}
+          #{default_actions(opts, table_spec)}
 
           postgres do
             table #{inspect(table_spec.table_name)}
@@ -300,12 +302,32 @@ if Code.ensure_loaded?(Igniter) do
 
     defp schema_option(_), do: ""
 
-    defp default_actions(opts) do
+    defp no_primary_key?(%AshPostgres.ResourceGenerator.Spec{attributes: attributes}) do
+      Enum.all?(attributes, &(not &1.primary_key?))
+    end
+
+    defp resource_block(table_spec) do
+      if no_primary_key?(table_spec) do
+        """
+        resource do
+          # WARNING: Configured to bypass missing primary key.
+          # Add primary_key?: true to your attributes/relationships and remove this block.
+          require_primary_key? false
+        end
+        """
+      else
+        ""
+      end
+    end
+
+    defp default_actions(opts, table_spec) do
       cond do
-        opts[:default_actions] && opts[:public] ->
+        no_primary_key?(table_spec) ->
           """
           actions do
-            defaults [:read, :destroy, create: :*, update: :*]
+            # WARNING: No primary key detected.
+            # :update and :destroy actions require a primary key to safely identify records.
+            defaults [:read, create: :*]
           end
           """
 

--- a/lib/resource_generator/resource_generator.ex
+++ b/lib/resource_generator/resource_generator.ex
@@ -264,6 +264,7 @@ if Code.ensure_loaded?(Igniter) do
 
     defp relationships_block(%{relationships: relationships} = spec, opts) do
       relationships
+      |> Enum.sort_by(&relationship_sort_key/1)
       |> Enum.map_join("\n", fn relationship ->
         case relationship_options(spec, relationship, opts) do
           "" ->
@@ -285,6 +286,11 @@ if Code.ensure_loaded?(Igniter) do
         """
       end)
     end
+
+    defp relationship_sort_key(%{type: :belongs_to, name: name}), do: {0, name}
+    defp relationship_sort_key(%{type: :has_one, name: name}), do: {1, name}
+    defp relationship_sort_key(%{type: :has_many, name: name}), do: {2, name}
+    defp relationship_sort_key(%{type: :many_to_many, name: name}), do: {3, name}
 
     defp schema_option(%{schema: schema}) when schema != "public" do
       "schema #{inspect(schema)}"
@@ -496,6 +502,7 @@ if Code.ensure_loaded?(Igniter) do
 
     defp add_relationships(str, %{relationships: relationships} = spec, opts) do
       relationships
+      |> Enum.sort_by(&relationship_sort_key/1)
       |> Enum.map_join("\n", fn relationship ->
         case relationship_options(spec, relationship, opts) do
           "" ->
@@ -659,7 +666,7 @@ if Code.ensure_loaded?(Igniter) do
             end)
 
           if relationship do
-            relationship = relationship.name
+            name = relationship.name
 
             options =
               ""
@@ -669,17 +676,20 @@ if Code.ensure_loaded?(Igniter) do
               |> add_match_type(foreign_key.match_type)
 
             [
-              """
-              reference :#{relationship} do
-                #{options}
-              end
-              """
+              {name,
+               """
+               reference :#{name} do
+                 #{options}
+               end
+               """}
             ]
           else
             []
           end
         end
       end)
+      |> Enum.sort_by(fn {name, _ref} -> name end)
+      |> Enum.map(fn {_name, ref} -> ref end)
       |> case do
         [] ->
           []

--- a/lib/resource_generator/spec.ex
+++ b/lib/resource_generator/spec.ex
@@ -85,7 +85,8 @@ defmodule AshPostgres.ResourceGenerator.Spec do
       :through,
       :source_attribute_on_join_resource,
       :destination_attribute_on_join_resource,
-      :join_relationship
+      :join_relationship,
+      :referenced_table
     ]
   end
 
@@ -631,56 +632,7 @@ defmodule AshPostgres.ResourceGenerator.Spec do
     specs =
       Enum.map(specs, fn spec ->
         belongs_to_relationships =
-          Enum.flat_map(
-            spec.foreign_keys,
-            fn %ForeignKey{
-                 constraint_name: constraint_name,
-                 column: column_name,
-                 references: references,
-                 destination_field: destination_field,
-                 match_with: match_with
-               } ->
-              case find_destination_and_field(
-                     specs,
-                     spec,
-                     references,
-                     destination_field,
-                     resources,
-                     match_with
-                   ) do
-                nil ->
-                  []
-
-                {destination, destination_attribute, match_with} ->
-                  source_attr =
-                    Enum.find(spec.attributes, fn attribute ->
-                      attribute.source == column_name
-                    end)
-
-                  [
-                    %Relationship{
-                      type: :belongs_to,
-                      name: Igniter.Inflex.singularize(references),
-                      source: spec.resource,
-                      constraint_name: constraint_name,
-                      match_with: match_with,
-                      destination: destination,
-                      source_attribute: source_attr.name,
-                      allow_nil?: source_attr.allow_nil?,
-                      destination_attribute: destination_attribute
-                    }
-                  ]
-              end
-            end
-          )
-          |> Enum.group_by(& &1.name)
-          |> Enum.flat_map(fn
-            {_name, [relationship]} ->
-              [relationship]
-
-            {name, relationships} ->
-              name_all_relationships(opts, spec, name, relationships)
-          end)
+          build_belongs_to_relationships(spec, specs, resources, opts)
 
         %{spec | relationships: belongs_to_relationships}
       end)
@@ -701,7 +653,7 @@ defmodule AshPostgres.ResourceGenerator.Spec do
 
           maybe_m2m =
             if !opts[:skip_many_to_many] do
-              build_many_to_many(spec, other_spec, relationship, reverse_rel, specs)
+              build_many_to_many_relationship(spec, other_spec, relationship, reverse_rel, specs)
             end
 
           [reverse_rel | List.wrap(maybe_m2m)]
@@ -719,7 +671,61 @@ defmodule AshPostgres.ResourceGenerator.Spec do
     end)
   end
 
-  defp build_many_to_many(spec, other_spec, relationship, reverse_rel, specs) do
+  defp build_belongs_to_relationships(spec, specs, resources, opts) do
+    Enum.flat_map(
+      spec.foreign_keys,
+      fn %ForeignKey{
+           constraint_name: constraint_name,
+           column: column_name,
+           references: references,
+           destination_field: destination_field,
+           match_with: match_with
+         } ->
+        case find_destination_and_field(
+               specs,
+               spec,
+               references,
+               destination_field,
+               resources,
+               match_with
+             ) do
+          nil ->
+            []
+
+          {destination, destination_attribute, match_with} ->
+            source_attr =
+              Enum.find(spec.attributes, fn attribute ->
+                attribute.source == column_name
+              end)
+
+            [
+              %Relationship{
+                type: :belongs_to,
+                name: default_belongs_to_name(column_name, references),
+                referenced_table: references,
+                source: spec.resource,
+                constraint_name: constraint_name,
+                match_with: match_with,
+                destination: destination,
+                source_attribute: source_attr.name,
+                allow_nil?: source_attr.allow_nil?,
+                destination_attribute: destination_attribute
+              }
+            ]
+        end
+      end
+    )
+    |> Enum.group_by(& &1.name)
+    |> Enum.flat_map(fn
+      {_name, [relationship]} ->
+        [relationship]
+
+      {name, relationships} ->
+        name_all_relationships(opts, spec, name, relationships)
+    end)
+  end
+
+  defp build_many_to_many_relationship(spec, other_spec, relationship, reverse_rel, specs) do
     with true <- join_table?(other_spec),
          other_fk when not is_nil(other_fk) <-
            Enum.find(other_spec.foreign_keys, &(&1.references != spec.table_name)),
@@ -806,82 +812,121 @@ defmodule AshPostgres.ResourceGenerator.Spec do
   defp name_all_relationships(_opts, _spec, _name, [], acc), do: acc
 
   defp name_all_relationships(opts, spec, name, [%Relationship{} = relationship | rest], acc) do
-    if opts[:yes?] || opts[:skip_unknown] do
-      name_all_relationships(opts, spec, name, rest, acc)
-    else
-      label =
-        case relationship.type do
-          :belongs_to ->
-            """
-            Multiple foreign keys found from `#{inspect(spec.resource)}` to `#{inspect(relationship.destination)}` with the guessed name `#{name}`.
+    {label, suggestion} =
+      case relationship.type do
+        :belongs_to ->
+          suggestion =
+            build_alternative_name(relationship.source_attribute, relationship.referenced_table)
 
-            Provide a relationship name for the one with the following info:
+          label = """
+          Multiple foreign keys found from `#{inspect(spec.resource)}` to `#{inspect(relationship.destination)}` with the guessed name `#{name}`.
 
-            Resource: `#{inspect(spec.resource)}`
-            Relationship Type: :belongs_to
-            Guessed Name: `:#{name}`
-            Relationship Destination: `#{inspect(relationship.destination)}`
-            Source Attribute (FK): `#{inspect(relationship.source_attribute)}`
-            Constraint Name: `#{inspect(relationship.constraint_name)}`.
+          Provide a relationship name for the one with the following info:
 
-            Leave empty to skip adding this relationship.
+          Resource: `#{inspect(spec.resource)}`
+          Relationship Type: :belongs_to
+          Guessed Name: `:#{name}`
+          Relationship Destination: `#{inspect(relationship.destination)}`
+          Source Attribute (FK): `#{inspect(relationship.source_attribute)}`
+          Constraint Name: `#{inspect(relationship.constraint_name)}`.
 
-            Name:
-            """
-            |> String.trim_trailing()
+          #{if suggestion == name do
+            "Leave empty to skip adding this relationship."
+          else
+            "Leave empty to use the suggested alternative name `#{suggestion}`."
+          end}
 
-          :many_to_many ->
-            """
-            Multiple :many_to_many relationships found between `#{inspect(relationship.source)}` and `#{inspect(relationship.destination)}` with the guessed name `#{name}`.
+          Name:
+          """
 
-            Provide a relationship name for the one with the following info:
+          {label, suggestion}
 
-            Resource: `#{inspect(relationship.source)}`
-            Relationship Type: :many_to_many
-            Guessed Name: `:#{name}`
-            Relationship Destination: `#{inspect(relationship.destination)}`
-            Join Resource (Through): `#{inspect(relationship.through)}`
+        :many_to_many ->
+          label = """
+          Multiple :many_to_many relationships found between `#{inspect(relationship.source)}` and `#{inspect(relationship.destination)}` with the guessed name `#{name}`.
 
-            Leave empty to skip adding this relationship.
+          Provide a relationship name for the one with the following info:
 
-            Name:
-            """
-            |> String.trim_trailing()
+          Resource: `#{inspect(relationship.source)}`
+          Relationship Type: :many_to_many
+          Guessed Name: `:#{name}`
+          Relationship Destination: `#{inspect(relationship.destination)}`
+          Join Resource (Through): `#{inspect(relationship.through)}`
 
-          _ ->
-            """
-            Multiple foreign keys found from `#{inspect(relationship.source)}` to `#{inspect(spec.resource)}` with the guessed name `#{name}`.
+          Leave empty to skip adding this relationship.
 
-            Provide a relationship name for the one with the following info:
+          Name:
+          """
 
-            Resource: `#{inspect(relationship.source)}`
-            Relationship Type: :#{relationship.type}
-            Guessed Name: `:#{name}`
-            Relationship Destination: `#{inspect(spec.resource)}`
-            Destination Attribute (FK): `#{inspect(relationship.destination_attribute)}`
-            Constraint Name: `#{inspect(relationship.constraint_name)}`.
+          {label, ""}
 
-            Leave empty to skip adding this relationship.
+        _ ->
+          suggestion = build_alternative_name(relationship.destination_attribute, name)
 
-            Name:
-            """
-            |> String.trim_trailing()
-        end
+          label = """
+          Multiple foreign keys found from `#{inspect(relationship.destination)}` to `#{inspect(spec.resource)}` with the guessed name `#{name}`.
 
-      Owl.IO.input(label: label, optional: true)
-      |> Kernel.||("")
-      # common typo
-      |> String.trim_leading(":")
-      |> case do
-        "" ->
-          name_all_relationships(opts, spec, name, rest, acc)
+          Provide a relationship name for the one with the following info:
 
-        new_name ->
-          name_all_relationships(opts, spec, name, rest, [
-            %{relationship | name: new_name} | acc
-          ])
+          Resource: `#{inspect(relationship.source)}`
+          Relationship Type: :#{relationship.type}
+          Guessed Name: `:#{name}`
+          Relationship Destination: `#{inspect(relationship.destination)}`
+          Destination Attribute (FK): `#{inspect(relationship.destination_attribute)}`
+          Constraint Name: `#{inspect(relationship.constraint_name)}`.
+
+          #{if suggestion == name do
+            "Leave empty to skip adding this relationship."
+          else
+            "Leave empty to use the suggested alternative name `#{suggestion}`."
+          end}
+
+          Name:
+          """
+
+          {label, suggestion}
       end
+
+    trimmed_label = String.trim_trailing(label)
+    maybe_suggestion = if suggestion == name, do: nil, else: suggestion
+
+    if opts[:yes] || opts[:skip_unknown] do
+      nil
+    else
+      Owl.IO.input(label: trimmed_label, optional: true)
     end
+    |> Kernel.||(maybe_suggestion)
+    # common typo
+    |> String.trim_leading(":")
+    |> case do
+      "" ->
+        name_all_relationships(opts, spec, name, rest, acc)
+
+      new_name ->
+        name_all_relationships(opts, spec, name, rest, [
+          %{relationship | name: new_name} | acc
+        ])
+    end
+  end
+
+  defp build_alternative_name(attribute, name) do
+    if String.ends_with?(attribute, "_id") do
+      attribute
+      |> String.replace("_id", "")
+      |> Igniter.Inflex.singularize()
+      |> Kernel.<>("_#{name}")
+    else
+      name
+    end
+  end
+
+  defp default_belongs_to_name(column_name, references) do
+    if String.ends_with?(column_name, "_id") and String.length(column_name) > 3 do
+      String.replace_suffix(column_name, "_id", "")
+    else
+      references
+    end
+    |> Igniter.Inflex.singularize()
   end
 
   defp find_destination_and_field(
@@ -983,7 +1028,7 @@ defmodule AshPostgres.ResourceGenerator.Spec do
   # sobelow_skip ["RCE.CodeModule", "DOS.StringToAtom"]
   defp get_type(attribute, opts) do
     result =
-      if opts[:yes?] || opts[:skip_unknown] do
+      if opts[:yes] || opts[:skip_unknown] do
         "skip"
       else
         Mix.shell().prompt("""

--- a/lib/resource_generator/spec.ex
+++ b/lib/resource_generator/spec.ex
@@ -809,11 +809,6 @@ defmodule AshPostgres.ResourceGenerator.Spec do
   end
 
   defp join_table?(spec) do
-    pk_cols =
-      spec.attributes
-      |> Enum.filter(& &1.primary_key?)
-      |> Enum.map(& &1.source)
-
     fk_cols = Enum.map(spec.foreign_keys, & &1.column)
 
     fk_tables =
@@ -823,7 +818,23 @@ defmodule AshPostgres.ResourceGenerator.Spec do
 
     length(spec.foreign_keys) == 2 &&
       length(fk_tables) == 2 &&
-      Enum.sort(pk_cols) == Enum.sort(fk_cols)
+      (pk_matches_fks?(spec, fk_cols) or unique_index_matches_fks?(spec, fk_cols))
+  end
+
+  defp pk_matches_fks?(spec, fk_cols) do
+    pk_cols =
+      spec.attributes
+      |> Enum.filter(& &1.primary_key?)
+      |> Enum.map(& &1.source)
+
+    pk_cols != [] and Enum.sort(pk_cols) == Enum.sort(fk_cols)
+  end
+
+  defp unique_index_matches_fks?(spec, fk_cols) do
+    Enum.any?(spec.indexes, fn idx ->
+      idx.unique? and is_nil(idx.where_clause) and
+        Enum.sort(idx.columns) == Enum.sort(fk_cols)
+    end)
   end
 
   defp resolve_name_collisions(relationships, opts, spec, reserved_names, initial_auto? \\ false) do

--- a/lib/resource_generator/spec.ex
+++ b/lib/resource_generator/spec.ex
@@ -81,7 +81,11 @@ defmodule AshPostgres.ResourceGenerator.Spec do
       :constraint_name,
       :destination_attribute,
       :allow_nil?,
-      :foreign_key
+      :foreign_key,
+      :through,
+      :source_attribute_on_join_resource,
+      :destination_attribute_on_join_resource,
+      :join_relationship
     ]
   end
 
@@ -675,7 +679,7 @@ defmodule AshPostgres.ResourceGenerator.Spec do
               [relationship]
 
             {name, relationships} ->
-              name_all_relationships(:belongs_to, opts, spec, name, relationships)
+              name_all_relationships(opts, spec, name, relationships)
           end)
 
         %{spec | relationships: belongs_to_relationships}
@@ -686,52 +690,21 @@ defmodule AshPostgres.ResourceGenerator.Spec do
         Enum.flat_map(specs, fn other_spec ->
           Enum.flat_map(other_spec.relationships, fn relationship ->
             if relationship.destination == spec.resource do
-              [{other_spec.table_name, other_spec.resource, relationship}]
+              [{other_spec.table_name, other_spec.resource, other_spec, relationship}]
             else
               []
             end
           end)
         end)
-        |> Enum.map(fn {table, resource, relationship} ->
-          destination_field =
-            Enum.find(spec.attributes, fn attribute ->
-              attribute.name == relationship.destination_attribute
-            end).source
+        |> Enum.flat_map(fn {table, resource, other_spec, relationship} ->
+          reverse_rel = build_has_relationship(spec, table, resource, relationship)
 
-          has_unique_index? =
-            Enum.any?(spec.indexes, fn index ->
-              index.unique? and is_nil(index.where_clause) and
-                index.columns == [destination_field]
-            end)
-
-          {name, type} =
-            if has_unique_index? do
-              if Igniter.Inflex.pluralize(table) == table do
-                {Igniter.Inflex.singularize(table), :has_one}
-              else
-                {table, :has_one}
-              end
-            else
-              if Igniter.Inflex.pluralize(table) == table do
-                {table, :has_many}
-              else
-                {Igniter.Inflex.pluralize(table), :has_many}
-              end
+          maybe_m2m =
+            if !opts[:skip_many_to_many] do
+              build_many_to_many(spec, other_spec, relationship, reverse_rel, specs)
             end
 
-          %Relationship{
-            type: type,
-            name: name,
-            destination: resource,
-            source: spec.resource,
-            match_with:
-              Enum.map(relationship.match_with, fn {source, dest} ->
-                {dest, source}
-              end),
-            constraint_name: relationship.constraint_name,
-            source_attribute: relationship.destination_attribute,
-            destination_attribute: relationship.source_attribute
-          }
+          [reverse_rel | List.wrap(maybe_m2m)]
         end)
         |> Enum.group_by(& &1.name)
         |> Enum.flat_map(fn
@@ -739,22 +712,105 @@ defmodule AshPostgres.ResourceGenerator.Spec do
             [relationship]
 
           {name, relationships} ->
-            name_all_relationships(:has, opts, spec, name, relationships)
+            name_all_relationships(opts, spec, name, relationships)
         end)
 
       %{spec | relationships: spec.relationships ++ relationships_to_me}
     end)
   end
 
-  defp name_all_relationships(type, opts, spec, name, relationships, acc \\ [])
-  defp name_all_relationships(_type, _opts, _spec, _name, [], acc), do: acc
+  defp build_many_to_many(spec, other_spec, relationship, reverse_rel, specs) do
+    with true <- join_table?(other_spec),
+         other_fk when not is_nil(other_fk) <-
+           Enum.find(other_spec.foreign_keys, &(&1.references != spec.table_name)),
+         dest_spec when not is_nil(dest_spec) <-
+           Enum.find(specs, &(&1.table_name == other_fk.references)) do
+      %Relationship{
+        type: :many_to_many,
+        name: safe_pluralize(other_fk.references),
+        source: spec.resource,
+        destination: dest_spec.resource,
+        through: other_spec.resource,
+        source_attribute: relationship.destination_attribute,
+        destination_attribute: other_fk.destination_field,
+        source_attribute_on_join_resource: relationship.source_attribute,
+        destination_attribute_on_join_resource: other_fk.column,
+        join_relationship: reverse_rel.name,
+        match_with: []
+      }
+    else
+      _ -> nil
+    end
+  end
 
-  defp name_all_relationships(type, opts, spec, name, [relationship | rest], acc) do
+  defp build_has_relationship(spec, table, resource, relationship) do
+    destination_field =
+      Enum.find(spec.attributes, fn attribute ->
+        attribute.name == relationship.destination_attribute
+      end).source
+
+    has_unique_index? =
+      Enum.any?(spec.indexes, fn index ->
+        index.unique? and is_nil(index.where_clause) and
+          index.columns == [destination_field]
+      end)
+
+    {name, type} =
+      if has_unique_index? do
+        {Igniter.Inflex.singularize(table), :has_one}
+      else
+        {safe_pluralize(table), :has_many}
+      end
+
+    %Relationship{
+      type: type,
+      name: name,
+      destination: resource,
+      source: spec.resource,
+      match_with:
+        Enum.map(relationship.match_with, fn {source, dest} ->
+          {dest, source}
+        end),
+      constraint_name: relationship.constraint_name,
+      source_attribute: relationship.destination_attribute,
+      destination_attribute: relationship.source_attribute
+    }
+  end
+
+  defp safe_pluralize(table) do
+    # handles edge cases when multiple pluralizations are possible like: "person" -> "people" -> "peoples"
+    table
+    |> Igniter.Inflex.singularize()
+    |> Igniter.Inflex.pluralize()
+  end
+
+  defp join_table?(spec) do
+    pk_cols =
+      spec.attributes
+      |> Enum.filter(& &1.primary_key?)
+      |> Enum.map(& &1.source)
+
+    fk_cols = Enum.map(spec.foreign_keys, & &1.column)
+
+    fk_tables =
+      spec.foreign_keys
+      |> Enum.map(& &1.references)
+      |> Enum.uniq()
+
+    length(spec.foreign_keys) == 2 &&
+      length(fk_tables) == 2 &&
+      Enum.sort(pk_cols) == Enum.sort(fk_cols)
+  end
+
+  defp name_all_relationships(opts, spec, name, relationships, acc \\ [])
+  defp name_all_relationships(_opts, _spec, _name, [], acc), do: acc
+
+  defp name_all_relationships(opts, spec, name, [%Relationship{} = relationship | rest], acc) do
     if opts[:yes?] || opts[:skip_unknown] do
-      name_all_relationships(type, opts, spec, name, rest, acc)
+      name_all_relationships(opts, spec, name, rest, acc)
     else
       label =
-        case type do
+        case relationship.type do
           :belongs_to ->
             """
             Multiple foreign keys found from `#{inspect(spec.resource)}` to `#{inspect(relationship.destination)}` with the guessed name `#{name}`.
@@ -765,7 +821,26 @@ defmodule AshPostgres.ResourceGenerator.Spec do
             Relationship Type: :belongs_to
             Guessed Name: `:#{name}`
             Relationship Destination: `#{inspect(relationship.destination)}`
+            Source Attribute (FK): `#{inspect(relationship.source_attribute)}`
             Constraint Name: `#{inspect(relationship.constraint_name)}`.
+
+            Leave empty to skip adding this relationship.
+
+            Name:
+            """
+            |> String.trim_trailing()
+
+          :many_to_many ->
+            """
+            Multiple :many_to_many relationships found between `#{inspect(relationship.source)}` and `#{inspect(relationship.destination)}` with the guessed name `#{name}`.
+
+            Provide a relationship name for the one with the following info:
+
+            Resource: `#{inspect(relationship.source)}`
+            Relationship Type: :many_to_many
+            Guessed Name: `:#{name}`
+            Relationship Destination: `#{inspect(relationship.destination)}`
+            Join Resource (Through): `#{inspect(relationship.through)}`
 
             Leave empty to skip adding this relationship.
 
@@ -783,6 +858,7 @@ defmodule AshPostgres.ResourceGenerator.Spec do
             Relationship Type: :#{relationship.type}
             Guessed Name: `:#{name}`
             Relationship Destination: `#{inspect(spec.resource)}`
+            Destination Attribute (FK): `#{inspect(relationship.destination_attribute)}`
             Constraint Name: `#{inspect(relationship.constraint_name)}`.
 
             Leave empty to skip adding this relationship.
@@ -798,10 +874,10 @@ defmodule AshPostgres.ResourceGenerator.Spec do
       |> String.trim_leading(":")
       |> case do
         "" ->
-          name_all_relationships(type, opts, spec, name, rest, acc)
+          name_all_relationships(opts, spec, name, rest, acc)
 
         new_name ->
-          name_all_relationships(type, opts, spec, name, rest, [
+          name_all_relationships(opts, spec, name, rest, [
             %{relationship | name: new_name} | acc
           ])
       end

--- a/lib/resource_generator/spec.ex
+++ b/lib/resource_generator/spec.ex
@@ -12,6 +12,7 @@ defmodule AshPostgres.ResourceGenerator.Spec do
     :repo,
     :resource,
     :schema,
+    kind: :table,
     check_constraints: [],
     foreign_keys: [],
     indexes: [],
@@ -93,35 +94,56 @@ defmodule AshPostgres.ResourceGenerator.Spec do
   def tables(repo, opts \\ []) do
     {:ok, result, _} =
       Ecto.Migrator.with_repo(repo, fn repo ->
-        repo
-        |> table_specs(opts)
-        |> Enum.group_by(&Enum.take(&1, 2), fn [_, _, field, type, default, size, allow_nil?] ->
-          name = Macro.underscore(field)
+        rows = table_specs(repo, opts)
 
-          %Attribute{
-            name: name,
-            source: field,
-            type: type,
-            migration_default: default,
-            size: size,
-            allow_nil?: allow_nil?
-          }
-        end)
+        relkinds =
+          Enum.reduce(rows, %{}, fn [table_name, table_schema, _, _, _, _, _, relkind], acc ->
+            Map.put_new(acc, {table_name, table_schema}, relkind_to_kind(relkind))
+          end)
+
+        rows
+        |> Enum.group_by(
+          &Enum.take(&1, 2),
+          fn [_, _, field, type, default, size, allow_nil?, _relkind] ->
+            name = Macro.underscore(field)
+
+            %Attribute{
+              name: name,
+              source: field,
+              type: type,
+              migration_default: default,
+              size: size,
+              allow_nil?: allow_nil?
+            }
+          end
+        )
         |> Enum.map(fn {[table_name, table_schema], attributes} ->
-          attributes = build_attributes(attributes, table_name, table_schema, repo, opts)
+          kind = Map.get(relkinds, {table_name, table_schema}, :table)
+
+          attributes = build_attributes(attributes, table_name, table_schema, repo, opts, kind)
 
           %__MODULE__{
             table_name: table_name,
             schema: table_schema,
             repo: repo,
+            kind: kind,
             attributes: attributes
           }
         end)
         |> Enum.map(fn spec ->
-          spec
-          |> add_foreign_keys()
-          |> add_indexes()
-          |> add_check_constraints()
+          case spec.kind do
+            :table ->
+              spec
+              |> add_foreign_keys()
+              |> add_indexes()
+              |> add_check_constraints()
+
+            :materialized_view ->
+              add_indexes(spec)
+
+            :view ->
+              spec
+          end
         end)
         |> Enum.reject(fn spec ->
           spec.table_name in List.wrap(opts[:skip_tables])
@@ -130,6 +152,11 @@ defmodule AshPostgres.ResourceGenerator.Spec do
 
     result
   end
+
+  defp relkind_to_kind("r"), do: :table
+  defp relkind_to_kind("v"), do: :view
+  defp relkind_to_kind("m"), do: :materialized_view
+  defp relkind_to_kind(_), do: :table
 
   defp qualified_table_name(%{schema: schema, table_name: table_name}) do
     "#{schema}.#{table_name}"
@@ -291,16 +318,16 @@ defmodule AshPostgres.ResourceGenerator.Spec do
           JOIN
               pg_class t ON ix.indrelid = t.oid
           JOIN
+              pg_catalog.pg_namespace tn ON tn.oid = t.relnamespace
+          JOIN
               pg_am am ON i.relam = am.oid
           LEFT JOIN
               pg_constraint c ON c.conindid = ix.indexrelid AND c.contype = 'p'
           JOIN
               pg_indexes idx ON idx.indexname = i.relname AND idx.schemaname = $2
-          JOIN information_schema.tables ta
-              ON ta.table_name = t.relname
           WHERE
               t.relname = $1
-              AND ta.table_schema = $2
+              AND tn.nspname = $2
               AND c.conindid IS NULL
           GROUP BY
               i.relname, ix.indisunique, ix.indnullsnotdistinct, pg_get_expr(ix.indpred, ix.indrelid), am.amname, idx.indexdef;
@@ -325,16 +352,16 @@ defmodule AshPostgres.ResourceGenerator.Spec do
           JOIN
               pg_class t ON ix.indrelid = t.oid
           JOIN
+              pg_catalog.pg_namespace tn ON tn.oid = t.relnamespace
+          JOIN
               pg_am am ON i.relam = am.oid
           LEFT JOIN
               pg_constraint c ON c.conindid = ix.indexrelid AND c.contype = 'p'
           JOIN
               pg_indexes idx ON idx.indexname = i.relname AND idx.schemaname = $2
-          JOIN information_schema.tables ta
-              ON ta.table_name = t.relname
           WHERE
               t.relname = $1
-              AND ta.table_schema = $2
+              AND tn.nspname = $2
               AND c.conindid IS NULL
           GROUP BY
               i.relname, ix.indisunique, pg_get_expr(ix.indpred, ix.indrelid), am.amname, idx.indexdef;
@@ -523,9 +550,9 @@ defmodule AshPostgres.ResourceGenerator.Spec do
     raise "Unexpected character: #{inspect(other)} at #{inspect(stack)} with #{inspect(field)} - #{inspect(acc)}"
   end
 
-  defp build_attributes(attributes, table_name, schema, repo, opts) do
+  defp build_attributes(attributes, table_name, schema, repo, opts, kind) do
     attributes
-    |> set_primary_key(table_name, schema, repo)
+    |> set_primary_key(table_name, schema, repo, kind)
     |> set_sensitive()
     |> set_types(opts)
     |> set_defaults_and_generated()
@@ -1116,7 +1143,11 @@ defmodule AshPostgres.ResourceGenerator.Spec do
     end)
   end
 
-  defp set_primary_key(attributes, table_name, schema, repo) do
+  defp set_primary_key(attributes, _table_name, _schema, _repo, kind) when kind != :table do
+    attributes
+  end
+
+  defp set_primary_key(attributes, table_name, schema, repo, _kind) do
     %Postgrex.Result{rows: pkey_rows} =
       repo.query!(
         """
@@ -1137,6 +1168,13 @@ defmodule AshPostgres.ResourceGenerator.Spec do
   end
 
   defp table_specs(repo, opts) do
+    relkind_filter =
+      if opts[:include_views] do
+        "IN ('r', 'v', 'm')"
+      else
+        "= 'r'"
+      end
+
     Enum.flat_map(opts[:tables] || ["public."], fn table ->
       {schema, table} =
         case String.split(table, ".") do
@@ -1147,95 +1185,54 @@ defmodule AshPostgres.ResourceGenerator.Spec do
             {"public", table}
         end
 
-      %{rows: rows} =
+      {table_filter, params} =
         if table == "" do
-          repo.query!(
-            """
-              SELECT
-                t.table_name,
-                t.table_schema,
-                c.column_name,
-                CASE WHEN c.data_type = 'ARRAY' THEN
-                  repeat('ARRAY of ', a.attndims) || REPLACE(c.udt_name, '_', '')
-                WHEN c.data_type = 'USER-DEFINED' THEN
-                  c.udt_name
-                ELSE
-                  c.data_type
-                END as data_type,
-                c.column_default,
-                c.character_maximum_length,
-                c.is_nullable = 'YES'
-              FROM
-                  information_schema.tables t
-              JOIN
-                  information_schema.columns c
-                  ON t.table_name = c.table_name
-              JOIN pg_attribute a
-                  ON a.attrelid = (
-                      SELECT c.oid
-                      FROM pg_class c
-                      JOIN pg_namespace n ON c.relnamespace = n.oid
-                      WHERE c.relname = t.table_name
-                        AND n.nspname = t.table_schema
-                        AND c.relkind = 'r'
-                    )
-                  AND a.attname = c.column_name
-                  AND a.attnum > 0
-              WHERE
-                  t.table_name NOT LIKE 'pg_%'
-                  AND t.table_name NOT LIKE '_pg_%'
-                  AND t.table_schema = $1
-              ORDER BY
-                  t.table_name,
-                  c.ordinal_position;
-            """,
-            [schema],
-            log: false
-          )
+          {"", [schema]}
         else
-          repo.query!(
-            """
-            SELECT
-              t.table_name,
-              t.table_schema,
-              c.column_name,
-              CASE WHEN c.data_type = 'ARRAY' THEN
-                repeat('ARRAY of ', a.attndims) || REPLACE(c.udt_name, '_', '')
-              WHEN c.data_type = 'USER-DEFINED' THEN
-                c.udt_name
-              ELSE
-                c.data_type
-              END as data_type,
-              c.column_default,
-              c.character_maximum_length,
-              c.is_nullable = 'YES'
-            FROM
-                information_schema.tables t
-            JOIN
-                information_schema.columns c
-                ON t.table_name = c.table_name
-            JOIN pg_attribute a
-                ON a.attrelid = (
-                    SELECT c.oid
-                    FROM pg_class c
-                    JOIN pg_namespace n ON c.relnamespace = n.oid
-                    WHERE c.relname = t.table_name
-                      AND n.nspname = t.table_schema
-                      AND c.relkind = 'r'
-                  )
-                AND a.attname = c.column_name
-                AND a.attnum > 0
-            WHERE
-                t.table_schema = $1
-                AND t.table_name = $2
-            ORDER BY
-                t.table_name,
-                c.ordinal_position;
-            """,
-            [schema, table],
-            log: false
-          )
+          {"AND c.relname = $2", [schema, table]}
         end
+
+      %{rows: rows} =
+        repo.query!(
+          """
+          SELECT
+            c.relname AS table_name,
+            n.nspname AS table_schema,
+            a.attname AS column_name,
+            CASE
+              WHEN t.typcategory = 'A' THEN
+                repeat('ARRAY of ', COALESCE(a.attndims, 1)) || REPLACE(et.typname, '_', '')
+              WHEN t.typtype = 'e' THEN
+                t.typname
+              ELSE
+                format_type(t.oid, NULL)
+            END AS data_type,
+            pg_get_expr(d.adbin, d.adrelid) AS column_default,
+            CASE
+              WHEN t.typname IN ('varchar', 'bpchar') AND a.atttypmod > 4 THEN a.atttypmod - 4
+              ELSE NULL
+            END AS character_maximum_length,
+            NOT a.attnotnull AS is_nullable,
+            c.relkind
+          FROM pg_catalog.pg_class c
+          JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+          JOIN pg_catalog.pg_attribute a ON a.attrelid = c.oid
+          JOIN pg_catalog.pg_type t ON t.oid = a.atttypid
+          LEFT JOIN pg_catalog.pg_type et ON et.oid = t.typelem
+          LEFT JOIN pg_catalog.pg_attrdef d
+            ON d.adrelid = a.attrelid AND d.adnum = a.attnum
+          WHERE c.relkind #{relkind_filter}
+            AND n.nspname = $1
+            AND a.attnum > 0
+            AND NOT a.attisdropped
+            AND c.relname NOT LIKE 'pg_%'
+            AND c.relname NOT LIKE '_pg_%'
+            #{table_filter}
+          ORDER BY c.relname, a.attnum;
+          """,
+          params,
+          log: false
+        )
 
       rows
     end)

--- a/lib/resource_generator/spec.ex
+++ b/lib/resource_generator/spec.ex
@@ -685,14 +685,11 @@ defmodule AshPostgres.ResourceGenerator.Spec do
 
           [reverse_rel | List.wrap(maybe_m2m)]
         end)
-        |> Enum.group_by(& &1.name)
-        |> Enum.flat_map(fn
-          {_name, [relationship]} ->
-            [relationship]
-
-          {name, relationships} ->
-            name_all_relationships(opts, spec, name, relationships)
-        end)
+        |> resolve_name_collisions(
+          opts,
+          spec,
+          Enum.map(spec.attributes, & &1.name) ++ Enum.map(spec.relationships, & &1.name)
+        )
 
       %{spec | relationships: spec.relationships ++ relationships_to_me}
     end)
@@ -742,14 +739,7 @@ defmodule AshPostgres.ResourceGenerator.Spec do
         end
       end
     )
-    |> Enum.group_by(& &1.name)
-    |> Enum.flat_map(fn
-      {_name, [relationship]} ->
-        [relationship]
-
-      {name, relationships} ->
-        name_all_relationships(opts, spec, name, relationships)
-    end)
+    |> resolve_name_collisions(opts, spec, Enum.map(spec.attributes, & &1.name))
   end
 
   defp build_many_to_many_relationship(spec, other_spec, relationship, reverse_rel, specs) do
@@ -764,6 +754,7 @@ defmodule AshPostgres.ResourceGenerator.Spec do
         source: spec.resource,
         destination: dest_spec.resource,
         through: other_spec.resource,
+        referenced_table: other_fk.references,
         source_attribute: relationship.destination_attribute,
         destination_attribute: other_fk.destination_field,
         source_attribute_on_join_resource: relationship.source_attribute,
@@ -835,98 +826,38 @@ defmodule AshPostgres.ResourceGenerator.Spec do
       Enum.sort(pk_cols) == Enum.sort(fk_cols)
   end
 
+  defp resolve_name_collisions(relationships, opts, spec, reserved_names) do
+    resolved =
+      relationships
+      |> Enum.group_by(& &1.name)
+      |> Enum.flat_map(fn {name, rels} ->
+        if length(rels) > 1 or name in reserved_names do
+          name_all_relationships(opts, spec, name, rels)
+        else
+          rels
+        end
+      end)
+
+    if same_relationship_names?(relationships, resolved) do
+      resolved
+    else
+      resolve_name_collisions(resolved, opts, spec, reserved_names)
+    end
+  end
+
+  defp same_relationship_names?(a, b) do
+    Enum.sort(Enum.map(a, & &1.name)) == Enum.sort(Enum.map(b, & &1.name))
+  end
+
   defp name_all_relationships(opts, spec, name, relationships, acc \\ [])
   defp name_all_relationships(_opts, _spec, _name, [], acc), do: acc
 
   defp name_all_relationships(opts, spec, name, [%Relationship{} = relationship | rest], acc) do
-    {label, suggestion} =
-      case relationship.type do
-        :belongs_to ->
-          suggestion =
-            build_alternative_name(relationship.source_attribute, relationship.referenced_table)
-
-          label = """
-          Multiple foreign keys found from `#{inspect(spec.resource)}` to `#{inspect(relationship.destination)}` with the guessed name `#{name}`.
-
-          Provide a relationship name for the one with the following info:
-
-          Resource: `#{inspect(spec.resource)}`
-          Relationship Type: :belongs_to
-          Guessed Name: `:#{name}`
-          Relationship Destination: `#{inspect(relationship.destination)}`
-          Source Attribute (FK): `#{inspect(relationship.source_attribute)}`
-          Constraint Name: `#{inspect(relationship.constraint_name)}`.
-
-          #{if suggestion == name do
-            "Leave empty to skip adding this relationship."
-          else
-            "Leave empty to use the suggested alternative name `#{suggestion}`."
-          end}
-
-          Name:
-          """
-
-          {label, suggestion}
-
-        :many_to_many ->
-          label = """
-          Multiple :many_to_many relationships found between `#{inspect(relationship.source)}` and `#{inspect(relationship.destination)}` with the guessed name `#{name}`.
-
-          Provide a relationship name for the one with the following info:
-
-          Resource: `#{inspect(relationship.source)}`
-          Relationship Type: :many_to_many
-          Guessed Name: `:#{name}`
-          Relationship Destination: `#{inspect(relationship.destination)}`
-          Join Resource (Through): `#{inspect(relationship.through)}`
-
-          Leave empty to skip adding this relationship.
-
-          Name:
-          """
-
-          {label, ""}
-
-        _ ->
-          suggestion = build_alternative_name(relationship.destination_attribute, name)
-
-          label = """
-          Multiple foreign keys found from `#{inspect(relationship.destination)}` to `#{inspect(spec.resource)}` with the guessed name `#{name}`.
-
-          Provide a relationship name for the one with the following info:
-
-          Resource: `#{inspect(relationship.source)}`
-          Relationship Type: :#{relationship.type}
-          Guessed Name: `:#{name}`
-          Relationship Destination: `#{inspect(relationship.destination)}`
-          Destination Attribute (FK): `#{inspect(relationship.destination_attribute)}`
-          Constraint Name: `#{inspect(relationship.constraint_name)}`.
-
-          #{if suggestion == name do
-            "Leave empty to skip adding this relationship."
-          else
-            "Leave empty to use the suggested alternative name `#{suggestion}`."
-          end}
-
-          Name:
-          """
-
-          {label, suggestion}
-      end
-
-    trimmed_label = String.trim_trailing(label)
+    {info, suggestion} = relationship_conflict_info(spec, name, relationship)
     maybe_suggestion = if suggestion == name, do: nil, else: suggestion
 
-    if opts[:yes] || opts[:skip_unknown] do
-      nil
-    else
-      Owl.IO.input(label: trimmed_label, optional: true)
-    end
-    |> Kernel.||(maybe_suggestion)
-    # common typo
-    |> String.trim_leading(":")
-    |> case do
-      "" ->
+    case choose_relationship_name(opts, name, maybe_suggestion, info) do
+      :skip ->
         name_all_relationships(opts, spec, name, rest, acc)
 
       new_name ->
@@ -936,12 +867,136 @@ defmodule AshPostgres.ResourceGenerator.Spec do
     end
   end
 
+  defp relationship_conflict_info(spec, name, %Relationship{type: :belongs_to} = relationship) do
+    suggestion =
+      build_alternative_name(relationship.source_attribute, relationship.referenced_table)
+
+    info = """
+    The guessed relationship name `:#{name}` on `#{inspect(spec.resource)}` conflicts with another name on this resource.
+
+    Relationship info:
+      Resource:                 #{inspect(spec.resource)}
+      Relationship Type:        :belongs_to
+      Guessed Name:             :#{name}
+      Relationship Destination: #{inspect(relationship.destination)}
+      Source Attribute (FK):    #{inspect(relationship.source_attribute)}
+      Constraint Name:          #{inspect(relationship.constraint_name)}
+    """
+
+    {info, suggestion}
+  end
+
+  defp relationship_conflict_info(_spec, name, %Relationship{type: :many_to_many} = relationship) do
+    suggestion =
+      build_alternative_name(relationship.source_attribute_on_join_resource, name)
+
+    info = """
+    The guessed relationship name `:#{name}` on `#{inspect(relationship.source)}` conflicts with another name on this resource.
+
+    Relationship info:
+      Resource:                      #{inspect(relationship.source)}
+      Relationship Type:             :many_to_many
+      Guessed Name:                  :#{name}
+      Relationship Destination:      #{inspect(relationship.destination)}
+      Destination Attribute on Join: #{inspect(relationship.destination_attribute_on_join_resource)}
+      Source Attribute on Join:      #{inspect(relationship.source_attribute_on_join_resource)}
+      Join Resource (Through):       #{inspect(relationship.through)}
+    """
+
+    {info, suggestion}
+  end
+
+  defp relationship_conflict_info(_spec, name, %Relationship{} = relationship) do
+    suggestion = build_alternative_name(relationship.destination_attribute, name)
+
+    info = """
+    The guessed relationship name `:#{name}` on `#{inspect(relationship.source)}` conflicts with another name on this resource.
+
+    Relationship info:
+      Resource:                   #{inspect(relationship.source)}
+      Relationship Type:          :#{relationship.type}
+      Guessed Name:               :#{name}
+      Relationship Destination:   #{inspect(relationship.destination)}
+      Destination Attribute (FK): #{inspect(relationship.destination_attribute)}
+      Constraint Name:            #{inspect(relationship.constraint_name)}
+    """
+
+    {info, suggestion}
+  end
+
+  defp choose_relationship_name(opts, name, maybe_suggestion, info) do
+    if opts[:yes] || opts[:skip_unknown] do
+      maybe_suggestion || :skip
+    else
+      prompt_relationship_name(name, maybe_suggestion, info)
+    end
+  end
+
+  defp prompt_relationship_name(name, maybe_suggestion, info) do
+    Owl.IO.puts(info)
+
+    options =
+      [
+        maybe_suggestion && {:suggest, "Use suggested name `:#{maybe_suggestion}`"},
+        {:skip, "Skip this relationship"}
+      ]
+      |> Enum.reject(&is_nil/1)
+
+    menu =
+      options
+      |> Enum.with_index(1)
+      |> Enum.map_join("\n", fn {{_action, label}, idx} -> "  #{idx}. #{label}" end)
+
+    prompt_label =
+      "How would you like to resolve the conflict for `:#{name}`?\n" <>
+        menu <> "\n  Or enter a custom name."
+
+    Owl.IO.input(
+      label: prompt_label,
+      optional: true,
+      cast: &parse_relationship_name_input(&1, options)
+    )
+    |> case do
+      :suggest -> maybe_suggestion || :skip
+      :skip -> :skip
+      nil -> maybe_suggestion || :skip
+      new_name -> new_name
+    end
+  end
+
+  defp parse_relationship_name_input(nil, _options), do: {:ok, nil}
+
+  defp parse_relationship_name_input(value, options) when is_binary(value) do
+    # common typo
+    trimmed = value |> String.trim() |> String.trim_leading(":")
+
+    case Integer.parse(trimmed) do
+      {idx, ""} when idx >= 1 ->
+        case Enum.at(options, idx - 1) do
+          {action, _label} -> {:ok, action}
+          nil -> {:error, "please choose a listed option or enter a custom name"}
+        end
+
+      _ ->
+        case trimmed do
+          "" -> {:ok, nil}
+          new_name -> {:ok, new_name}
+        end
+    end
+  end
+
   defp build_alternative_name(attribute, name) do
     if String.ends_with?(attribute, "_id") do
-      attribute
-      |> String.replace("_id", "")
-      |> Igniter.Inflex.singularize()
-      |> Kernel.<>("_#{name}")
+      stripped =
+        attribute
+        |> String.replace("_id", "")
+        |> Igniter.Inflex.singularize()
+
+      if stripped == Igniter.Inflex.singularize(to_string(name)) do
+        name
+      else
+        "#{stripped}_#{name}"
+      end
     else
       name
     end

--- a/lib/resource_generator/spec.ex
+++ b/lib/resource_generator/spec.ex
@@ -826,22 +826,30 @@ defmodule AshPostgres.ResourceGenerator.Spec do
       Enum.sort(pk_cols) == Enum.sort(fk_cols)
   end
 
-  defp resolve_name_collisions(relationships, opts, spec, reserved_names) do
-    resolved =
-      relationships
-      |> Enum.group_by(& &1.name)
-      |> Enum.flat_map(fn {name, rels} ->
+  defp resolve_name_collisions(relationships, opts, spec, reserved_names, initial_auto? \\ false) do
+    groups = Enum.group_by(relationships, & &1.name)
+
+    total =
+      Enum.reduce(groups, 0, fn {name, rels}, acc ->
+        if length(rels) > 1 or name in reserved_names, do: acc + length(rels), else: acc
+      end)
+
+    {resolved, _seen, auto?} =
+      Enum.reduce(groups, {[], 0, initial_auto?}, fn {name, rels}, {acc, seen, auto?} ->
         if length(rels) > 1 or name in reserved_names do
-          name_all_relationships(opts, spec, name, rels)
+          {new_rels, seen, auto?} =
+            name_all_relationships(opts, spec, name, rels, {seen, total}, auto?)
+
+          {acc ++ new_rels, seen, auto?}
         else
-          rels
+          {acc ++ rels, seen, auto?}
         end
       end)
 
     if same_relationship_names?(relationships, resolved) do
       resolved
     else
-      resolve_name_collisions(resolved, opts, spec, reserved_names)
+      resolve_name_collisions(resolved, opts, spec, reserved_names, auto?)
     end
   end
 
@@ -849,19 +857,33 @@ defmodule AshPostgres.ResourceGenerator.Spec do
     Enum.sort(Enum.map(a, & &1.name)) == Enum.sort(Enum.map(b, & &1.name))
   end
 
-  defp name_all_relationships(opts, spec, name, relationships, acc \\ [])
-  defp name_all_relationships(_opts, _spec, _name, [], acc), do: acc
+  defp name_all_relationships(opts, spec, name, relationships, progress, auto?, acc \\ [])
 
-  defp name_all_relationships(opts, spec, name, [%Relationship{} = relationship | rest], acc) do
+  defp name_all_relationships(_opts, _spec, _name, [], {seen, _total}, auto?, acc),
+    do: {acc, seen, auto?}
+
+  defp name_all_relationships(
+         opts,
+         spec,
+         name,
+         [%Relationship{} = relationship | rest],
+         {seen, total},
+         auto?,
+         acc
+       ) do
     {info, suggestion} = relationship_conflict_info(spec, name, relationship)
     maybe_suggestion = if suggestion == name, do: nil, else: suggestion
+    progress = {seen + 1, total}
 
-    case choose_relationship_name(opts, name, maybe_suggestion, info) do
+    {choice, auto?} =
+      choose_relationship_name(opts, name, maybe_suggestion, info, progress, auto?)
+
+    case choice do
       :skip ->
-        name_all_relationships(opts, spec, name, rest, acc)
+        name_all_relationships(opts, spec, name, rest, {seen + 1, total}, auto?, acc)
 
       new_name ->
-        name_all_relationships(opts, spec, name, rest, [
+        name_all_relationships(opts, spec, name, rest, {seen + 1, total}, auto?, [
           %{relationship | name: new_name} | acc
         ])
     end
@@ -924,31 +946,41 @@ defmodule AshPostgres.ResourceGenerator.Spec do
     {info, suggestion}
   end
 
-  defp choose_relationship_name(opts, name, maybe_suggestion, info) do
-    if opts[:yes] || opts[:skip_unknown] do
-      maybe_suggestion || :skip
-    else
-      prompt_relationship_name(name, maybe_suggestion, info)
+  defp choose_relationship_name(opts, name, maybe_suggestion, info, progress, auto?) do
+    cond do
+      auto? ->
+        {maybe_suggestion || :skip, true}
+
+      opts[:yes] || opts[:skip_unknown] ->
+        {maybe_suggestion || :skip, false}
+
+      true ->
+        prompt_relationship_name(name, maybe_suggestion, info, progress)
     end
   end
 
-  defp prompt_relationship_name(name, maybe_suggestion, info) do
+  defp prompt_relationship_name(name, maybe_suggestion, info, {seen, total}) do
     Owl.IO.puts(info)
 
+    # Slot numbers are fixed so a given action always lives at the same digit,
+    # even when an option is absent (e.g. no suggestion available).
     options =
       [
-        maybe_suggestion && {:suggest, "Use suggested name `:#{maybe_suggestion}`"},
-        {:skip, "Skip this relationship"}
+        maybe_suggestion && {1, :suggest, "Use suggested name `:#{maybe_suggestion}`"},
+        seen < total &&
+          {2, :auto,
+           "Auto-resolve remaining conflicts on this resource (use suggestion when available, otherwise skip)"},
+        {3, :skip, "Skip this relationship"}
       ]
-      |> Enum.reject(&is_nil/1)
+      |> Enum.reject(&(&1 in [nil, false]))
 
     menu =
-      options
-      |> Enum.with_index(1)
-      |> Enum.map_join("\n", fn {{_action, label}, idx} -> "  #{idx}. #{label}" end)
+      Enum.map_join(options, "\n", fn {slot, _action, label} -> "  #{slot}. #{label}" end)
+
+    progress_tag = if total > 1, do: " [#{seen}/#{total}]", else: ""
 
     prompt_label =
-      "How would you like to resolve the conflict for `:#{name}`?\n" <>
+      "How would you like to resolve the conflict for `:#{name}`?#{progress_tag}\n" <>
         menu <> "\n  Or enter a custom name."
 
     Owl.IO.input(
@@ -957,10 +989,11 @@ defmodule AshPostgres.ResourceGenerator.Spec do
       cast: &parse_relationship_name_input(&1, options)
     )
     |> case do
-      :suggest -> maybe_suggestion || :skip
-      :skip -> :skip
-      nil -> maybe_suggestion || :skip
-      new_name -> new_name
+      :suggest -> {maybe_suggestion || :skip, false}
+      :skip -> {:skip, false}
+      :auto -> {maybe_suggestion || :skip, true}
+      nil -> {maybe_suggestion || :skip, false}
+      new_name -> {new_name, false}
     end
   end
 
@@ -971,9 +1004,9 @@ defmodule AshPostgres.ResourceGenerator.Spec do
     trimmed = value |> String.trim() |> String.trim_leading(":")
 
     case Integer.parse(trimmed) do
-      {idx, ""} when idx >= 1 ->
-        case Enum.at(options, idx - 1) do
-          {action, _label} -> {:ok, action}
+      {slot, ""} when slot >= 1 ->
+        case Enum.find(options, fn {s, _action, _label} -> s == slot end) do
+          {_slot, action, _label} -> {:ok, action}
           nil -> {:error, "please choose a listed option or enter a custom name"}
         end
 
@@ -992,10 +1025,12 @@ defmodule AshPostgres.ResourceGenerator.Spec do
         |> String.replace("_id", "")
         |> Igniter.Inflex.singularize()
 
-      if stripped == Igniter.Inflex.singularize(to_string(name)) do
-        name
-      else
-        "#{stripped}_#{name}"
+      name_str = to_string(name)
+
+      cond do
+        stripped == Igniter.Inflex.singularize(name_str) -> name
+        String.contains?(name_str, stripped) -> name
+        true -> "#{stripped}_#{name_str}"
       end
     else
       name

--- a/test/resource_generator_test.exs
+++ b/test/resource_generator_test.exs
@@ -435,4 +435,285 @@ defmodule AshPostgres.ResourceGeenratorTests do
       """)
     end
   end
+
+  defp file_content(igniter, path) do
+    source = igniter.rewrite.sources[path]
+    assert source, "Expected #{inspect(path)} to be created"
+    Rewrite.Source.get(source, :content)
+  end
+
+  describe "many_to_many relationship generation" do
+    setup do
+      AshPostgres.TestRepo.query!("DROP TABLE IF EXISTS article_tags CASCADE")
+      AshPostgres.TestRepo.query!("DROP TABLE IF EXISTS articles CASCADE")
+      AshPostgres.TestRepo.query!("DROP TABLE IF EXISTS topics CASCADE")
+
+      AshPostgres.TestRepo.query!("""
+      CREATE TABLE articles (
+        id UUID DEFAULT uuid_generate_v4() PRIMARY KEY,
+        title VARCHAR(255)
+      )
+      """)
+
+      AshPostgres.TestRepo.query!("""
+      CREATE TABLE topics (
+        id UUID DEFAULT uuid_generate_v4() PRIMARY KEY,
+        name VARCHAR(255)
+      )
+      """)
+
+      AshPostgres.TestRepo.query!("""
+      CREATE TABLE article_tags (
+        article_id UUID NOT NULL REFERENCES articles(id),
+        topic_id UUID NOT NULL REFERENCES topics(id),
+        PRIMARY KEY (article_id, topic_id)
+      )
+      """)
+
+      :ok
+    end
+
+    test "generates has_many to the join table alongside many_to_many to the destination" do
+      test_project()
+      |> Igniter.compose_task("ash_postgres.gen.resources", [
+        "MyApp.Blog",
+        "--tables",
+        "articles,topics,article_tags",
+        "--yes",
+        "--repo",
+        "AshPostgres.TestRepo"
+      ])
+      |> assert_creates("lib/my_app/blog/article.ex", """
+      defmodule MyApp.Blog.Article do
+        use Ash.Resource,
+          domain: MyApp.Blog,
+          data_layer: AshPostgres.DataLayer
+
+        actions do
+          defaults([:read, :destroy, create: :*, update: :*])
+        end
+
+        postgres do
+          table("articles")
+          repo(AshPostgres.TestRepo)
+        end
+
+        attributes do
+          uuid_primary_key :id do
+            public?(true)
+          end
+
+          attribute :title, :string do
+            public?(true)
+          end
+        end
+
+        relationships do
+          has_many :article_tags, MyApp.Blog.ArticleTag do
+            public?(true)
+          end
+
+          many_to_many :topics, MyApp.Blog.Topic do
+            through(MyApp.Blog.ArticleTag)
+            join_relationship(:article_tags)
+            public?(true)
+          end
+        end
+      end
+      """)
+      |> assert_creates("lib/my_app/blog/topic.ex", """
+      defmodule MyApp.Blog.Topic do
+        use Ash.Resource,
+          domain: MyApp.Blog,
+          data_layer: AshPostgres.DataLayer
+
+        actions do
+          defaults([:read, :destroy, create: :*, update: :*])
+        end
+
+        postgres do
+          table("topics")
+          repo(AshPostgres.TestRepo)
+        end
+
+        attributes do
+          uuid_primary_key :id do
+            public?(true)
+          end
+
+          attribute :name, :string do
+            public?(true)
+          end
+        end
+
+        relationships do
+          has_many :article_tags, MyApp.Blog.ArticleTag do
+            public?(true)
+          end
+
+          many_to_many :articles, MyApp.Blog.Article do
+            through(MyApp.Blog.ArticleTag)
+            join_relationship(:article_tags)
+            public?(true)
+          end
+        end
+      end
+      """)
+    end
+
+    test "join table resource itself gets only belongs_to relationships" do
+      igniter =
+        test_project()
+        |> Igniter.compose_task("ash_postgres.gen.resources", [
+          "MyApp.Blog",
+          "--tables",
+          "articles,topics,article_tags",
+          "--yes",
+          "--repo",
+          "AshPostgres.TestRepo"
+        ])
+
+      content = file_content(igniter, "lib/my_app/blog/article_tag.ex")
+      assert content =~ "belongs_to :article, MyApp.Blog.Article"
+      assert content =~ "belongs_to :topic, MyApp.Blog.Topic"
+      refute content =~ "many_to_many"
+      refute content =~ "has_many"
+    end
+
+    test "omits source/dest join attributes when they match the module-name defaults" do
+      igniter =
+        test_project()
+        |> Igniter.compose_task("ash_postgres.gen.resources", [
+          "MyApp.Blog",
+          "--tables",
+          "articles,topics,article_tags",
+          "--yes",
+          "--repo",
+          "AshPostgres.TestRepo"
+        ])
+
+      content = file_content(igniter, "lib/my_app/blog/article.ex")
+      # article_id and topic_id match defaults → options omitted
+      refute content =~ "source_attribute_on_join_resource"
+      refute content =~ "destination_attribute_on_join_resource"
+    end
+
+    test "emits source/dest join attributes when FK column names differ from module-name defaults" do
+      AshPostgres.TestRepo.query!("DROP TABLE IF EXISTS article_mappings CASCADE")
+
+      AshPostgres.TestRepo.query!("""
+      CREATE TABLE article_mappings (
+        the_article UUID NOT NULL REFERENCES articles(id),
+        the_topic   UUID NOT NULL REFERENCES topics(id),
+        PRIMARY KEY (the_article, the_topic)
+      )
+      """)
+
+      igniter =
+        test_project()
+        |> Igniter.compose_task("ash_postgres.gen.resources", [
+          "MyApp.Blog",
+          "--tables",
+          "articles,topics,article_mappings",
+          "--yes",
+          "--repo",
+          "AshPostgres.TestRepo"
+        ])
+
+      content = file_content(igniter, "lib/my_app/blog/article.ex")
+      assert content =~ "source_attribute_on_join_resource(:the_article)"
+      assert content =~ "destination_attribute_on_join_resource(:the_topic)"
+    end
+
+    test "does not generate many_to_many when the join table has its own surrogate primary key" do
+      AshPostgres.TestRepo.query!("DROP TABLE IF EXISTS article_labels CASCADE")
+
+      AshPostgres.TestRepo.query!("""
+      CREATE TABLE article_labels (
+        id         UUID DEFAULT uuid_generate_v4() PRIMARY KEY,
+        article_id UUID NOT NULL REFERENCES articles(id),
+        topic_id   UUID NOT NULL REFERENCES topics(id)
+      )
+      """)
+
+      igniter =
+        test_project()
+        |> Igniter.compose_task("ash_postgres.gen.resources", [
+          "MyApp.Blog",
+          "--tables",
+          "articles,topics,article_labels",
+          "--yes",
+          "--repo",
+          "AshPostgres.TestRepo"
+        ])
+
+      article_content = file_content(igniter, "lib/my_app/blog/article.ex")
+      assert article_content =~ "has_many :article_labels"
+      refute article_content =~ "many_to_many"
+
+      topic_content = file_content(igniter, "lib/my_app/blog/topic.ex")
+      assert topic_content =~ "has_many :article_labels"
+      refute topic_content =~ "many_to_many"
+    end
+
+    test "--skip-many-to-many generates only has_many for detected join tables" do
+      igniter =
+        test_project()
+        |> Igniter.compose_task("ash_postgres.gen.resources", [
+          "MyApp.Blog",
+          "--tables",
+          "articles,topics,article_tags",
+          "--yes",
+          "--repo",
+          "AshPostgres.TestRepo",
+          "--skip-many-to-many"
+        ])
+
+      article_content = file_content(igniter, "lib/my_app/blog/article.ex")
+      assert article_content =~ "has_many :article_tags"
+      refute article_content =~ "many_to_many"
+
+      topic_content = file_content(igniter, "lib/my_app/blog/topic.ex")
+      assert topic_content =~ "has_many :article_tags"
+      refute topic_content =~ "many_to_many"
+    end
+
+    test "falls back to has_many when the destination table is excluded from generation" do
+      # topics excluded → build_many_to_many can't find dest_spec → returns nil
+      igniter =
+        test_project()
+        |> Igniter.compose_task("ash_postgres.gen.resources", [
+          "MyApp.Blog",
+          "--tables",
+          "articles,article_tags",
+          "--yes",
+          "--repo",
+          "AshPostgres.TestRepo"
+        ])
+
+      content = file_content(igniter, "lib/my_app/blog/article.ex")
+      assert content =~ "has_many :article_tags"
+      refute content =~ "many_to_many"
+    end
+
+    test "generates many_to_many correctly in fragment mode" do
+      igniter =
+        test_project()
+        |> Igniter.compose_task("ash_postgres.gen.resources", [
+          "MyApp.Blog",
+          "--tables",
+          "articles,topics,article_tags",
+          "--yes",
+          "--repo",
+          "AshPostgres.TestRepo",
+          "--fragments"
+        ])
+
+      content = file_content(igniter, "lib/my_app/blog/article/model.ex")
+      assert content =~ "has_many :article_tags, MyApp.Blog.ArticleTag"
+      assert content =~ "many_to_many :topics, MyApp.Blog.Topic"
+      assert content =~ "through"
+      assert content =~ "join_relationship"
+    end
+  end
 end

--- a/test/resource_generator_test.exs
+++ b/test/resource_generator_test.exs
@@ -893,6 +893,41 @@ defmodule AshPostgres.ResourceGeenratorTests do
       assert content =~ "destination_attribute_on_join_resource(:the_topic)"
     end
 
+    test "detects many_to_many when the join table has a unique index over the FK columns instead of a composite primary key" do
+      # Hibernate / legacy schemas often use UNIQUE(a, b) instead of PRIMARY KEY (a, b).
+      AshPostgres.TestRepo.query!("DROP TABLE IF EXISTS article_uq_tags CASCADE")
+
+      AshPostgres.TestRepo.query!("""
+      CREATE TABLE article_uq_tags (
+        article_id UUID NOT NULL REFERENCES articles(id),
+        topic_id   UUID NOT NULL REFERENCES topics(id)
+      )
+      """)
+
+      AshPostgres.TestRepo.query!(
+        "CREATE UNIQUE INDEX article_uq_tags_uniq ON article_uq_tags (article_id, topic_id)"
+      )
+
+      igniter =
+        test_project()
+        |> Igniter.compose_task("ash_postgres.gen.resources", [
+          "MyApp.Blog",
+          "--tables",
+          "articles,topics,article_uq_tags",
+          "--yes",
+          "--repo",
+          "AshPostgres.TestRepo"
+        ])
+
+      article_content = file_content(igniter, "lib/my_app/blog/article.ex")
+      assert article_content =~ "many_to_many :topics, MyApp.Blog.Topic"
+      assert article_content =~ "has_many :article_uq_tags"
+
+      topic_content = file_content(igniter, "lib/my_app/blog/topic.ex")
+      assert topic_content =~ "many_to_many :articles, MyApp.Blog.Article"
+      assert topic_content =~ "has_many :article_uq_tags"
+    end
+
     test "does not generate many_to_many when the join table has its own surrogate primary key" do
       AshPostgres.TestRepo.query!("DROP TABLE IF EXISTS article_labels CASCADE")
 

--- a/test/resource_generator_test.exs
+++ b/test/resource_generator_test.exs
@@ -656,6 +656,34 @@ defmodule AshPostgres.ResourceGeenratorTests do
       refute topic_content =~ "many_to_many"
     end
 
+    test "does not generate many_to_many for self-referential join tables" do
+      # Both FKs point to the same table → join_table? returns false because
+      # fk_tables has length 1, not 2
+      AshPostgres.TestRepo.query!("DROP TABLE IF EXISTS article_links CASCADE")
+
+      AshPostgres.TestRepo.query!("""
+      CREATE TABLE article_links (
+        source_id UUID NOT NULL REFERENCES articles(id),
+        target_id UUID NOT NULL REFERENCES articles(id),
+        PRIMARY KEY (source_id, target_id)
+      )
+      """)
+
+      igniter =
+        test_project()
+        |> Igniter.compose_task("ash_postgres.gen.resources", [
+          "MyApp.Blog",
+          "--tables",
+          "articles,article_links",
+          "--yes",
+          "--repo",
+          "AshPostgres.TestRepo"
+        ])
+
+      content = file_content(igniter, "lib/my_app/blog/article.ex")
+      refute content =~ "many_to_many"
+    end
+
     test "--skip-many-to-many generates only has_many for detected join tables" do
       igniter =
         test_project()
@@ -714,6 +742,119 @@ defmodule AshPostgres.ResourceGeenratorTests do
       assert content =~ "many_to_many :topics, MyApp.Blog.Topic"
       assert content =~ "through"
       assert content =~ "join_relationship"
+    end
+  end
+
+  describe "inferring relationship names from foreign keys with _id suffix" do
+    setup do
+      AshPostgres.TestRepo.query!("DROP TABLE IF EXISTS people CASCADE")
+      AshPostgres.TestRepo.query!("DROP TABLE IF EXISTS articles CASCADE")
+
+      AshPostgres.TestRepo.query!("""
+      CREATE TABLE people (
+        id UUID DEFAULT uuid_generate_v4() PRIMARY KEY,
+        name VARCHAR(255)
+      )
+      """)
+
+      AshPostgres.TestRepo.query!("""
+      CREATE TABLE articles (
+        id UUID DEFAULT uuid_generate_v4() PRIMARY KEY,
+        title VARCHAR(255),
+        author_id UUID NOT NULL REFERENCES people(id),
+        reviewer_id UUID NOT NULL REFERENCES people(id)
+      )
+      """)
+
+      :ok
+    end
+
+    test "avoids naming collisions by appending table name for has_many relationships when multiple references exist" do
+      test_project()
+      |> Igniter.compose_task("ash_postgres.gen.resources", [
+        "MyApp.Blog",
+        "--tables",
+        "articles,people",
+        "--yes",
+        "--repo",
+        "AshPostgres.TestRepo"
+      ])
+      |> assert_creates("lib/my_app/blog/article.ex", """
+      defmodule MyApp.Blog.Article do
+        use Ash.Resource,
+          domain: MyApp.Blog,
+          data_layer: AshPostgres.DataLayer
+
+        actions do
+          defaults([:read, :destroy, create: :*, update: :*])
+        end
+
+        postgres do
+          table("articles")
+          repo(AshPostgres.TestRepo)
+        end
+
+        attributes do
+          uuid_primary_key :id do
+            public?(true)
+          end
+
+          attribute :title, :string do
+            public?(true)
+          end
+        end
+
+        relationships do
+          belongs_to :author, MyApp.Blog.Person do
+            allow_nil?(false)
+            public?(true)
+          end
+
+          belongs_to :reviewer, MyApp.Blog.Person do
+            allow_nil?(false)
+            public?(true)
+          end
+        end
+      end
+      """)
+      |> assert_creates("lib/my_app/blog/person.ex", """
+      defmodule MyApp.Blog.Person do
+        use Ash.Resource,
+          domain: MyApp.Blog,
+          data_layer: AshPostgres.DataLayer
+
+        actions do
+          defaults([:read, :destroy, create: :*, update: :*])
+        end
+
+        postgres do
+          table("people")
+          repo(AshPostgres.TestRepo)
+        end
+
+        attributes do
+          uuid_primary_key :id do
+            public?(true)
+          end
+
+          attribute :name, :string do
+            public?(true)
+          end
+        end
+
+        relationships do
+          has_many :reviewer_articles, MyApp.Blog.Article do
+            destination_attribute(:reviewer_id)
+            public?(true)
+          end
+
+          has_many :author_articles, MyApp.Blog.Article do
+            destination_attribute(:author_id)
+            public?(true)
+          end
+        end
+      end
+      """)
     end
   end
 end

--- a/test/resource_generator_test.exs
+++ b/test/resource_generator_test.exs
@@ -120,6 +120,198 @@ defmodule AshPostgres.ResourceGeenratorTests do
     """)
   end
 
+  test "a resource is generated from a VIEW when --include-views is set" do
+    AshPostgres.TestRepo.query!("DROP VIEW IF EXISTS example_view")
+    AshPostgres.TestRepo.query!("DROP TABLE IF EXISTS example_view_source")
+
+    AshPostgres.TestRepo.query!("CREATE TABLE example_view_source (
+      id UUID DEFAULT uuid_generate_v4() PRIMARY KEY,
+      amount INTEGER NOT NULL
+    )")
+
+    AshPostgres.TestRepo.query!(
+      "CREATE VIEW example_view AS SELECT id, amount * 2 AS doubled FROM example_view_source"
+    )
+
+    test_project()
+    |> Igniter.compose_task("ash_postgres.gen.resources", [
+      "MyApp.Accounts",
+      "--tables",
+      "example_view",
+      "--yes",
+      "--repo",
+      "AshPostgres.TestRepo",
+      "--include-views"
+    ])
+    |> assert_creates("lib/my_app/accounts/example_view.ex", """
+    defmodule MyApp.Accounts.ExampleView do
+      use Ash.Resource,
+        domain: MyApp.Accounts,
+        data_layer: AshPostgres.DataLayer
+
+      resource do
+        # WARNING: Configured to bypass missing primary key.
+        # Add primary_key?: true to your attributes/relationships and remove this block.
+        require_primary_key?(false)
+      end
+
+      actions do
+        # WARNING: Generated from a PostgreSQL VIEW.
+        # Views are read-only; only the :read default action is safe.
+        defaults([:read])
+      end
+
+      postgres do
+        table("example_view")
+        repo(AshPostgres.TestRepo)
+
+        # NOTE: Source is a PostgreSQL VIEW, not a base table.
+        # migrate? false prevents Ash from trying to manage its schema.
+        # TODO: Migrations need to be handled manually for views.
+        migrate?(false)
+      end
+
+      attributes do
+        attribute :id, :uuid do
+          public?(true)
+        end
+
+        attribute :doubled, :integer do
+          public?(true)
+        end
+      end
+    end
+    """)
+  end
+
+  test "a resource is generated from a MATERIALIZED VIEW when --include-views is set" do
+    AshPostgres.TestRepo.query!("DROP MATERIALIZED VIEW IF EXISTS example_mv")
+    AshPostgres.TestRepo.query!("DROP TABLE IF EXISTS example_mv_source")
+
+    AshPostgres.TestRepo.query!("CREATE TABLE example_mv_source (
+      id UUID DEFAULT uuid_generate_v4() PRIMARY KEY,
+      category VARCHAR(64) NOT NULL,
+      amount INTEGER NOT NULL
+    )")
+
+    AshPostgres.TestRepo.query!("""
+    CREATE MATERIALIZED VIEW example_mv AS
+    SELECT id, category, amount * 2 AS doubled FROM example_mv_source
+    """)
+
+    AshPostgres.TestRepo.query!("CREATE UNIQUE INDEX example_mv_id_unique ON example_mv(id)")
+
+    test_project()
+    |> Igniter.compose_task("ash_postgres.gen.resources", [
+      "MyApp.Accounts",
+      "--tables",
+      "example_mv",
+      "--yes",
+      "--repo",
+      "AshPostgres.TestRepo",
+      "--include-views"
+    ])
+    |> assert_creates("lib/my_app/accounts/example_mv.ex", """
+    defmodule MyApp.Accounts.ExampleMv do
+      use Ash.Resource,
+        domain: MyApp.Accounts,
+        data_layer: AshPostgres.DataLayer
+
+      resource do
+        # WARNING: Configured to bypass missing primary key.
+        # Add primary_key?: true to your attributes/relationships and remove this block.
+        require_primary_key?(false)
+      end
+
+      actions do
+        # WARNING: Generated from a PostgreSQL MATERIALIZED VIEW.
+        # Views are read-only; only the :read default action is safe.
+        defaults([:read])
+      end
+
+      postgres do
+        table("example_mv")
+        repo(AshPostgres.TestRepo)
+
+        # NOTE: Source is a PostgreSQL MATERIALIZED VIEW, not a base table.
+        # migrate? false prevents Ash from trying to manage its schema.
+        # TODO: Migrations need to be handled manually for views.
+        migrate?(false)
+
+        identity_index_names(id_unique: "example_mv_id_unique")
+      end
+
+      attributes do
+        attribute :id, :uuid do
+          public?(true)
+        end
+
+        attribute :category, :string do
+          public?(true)
+        end
+
+        attribute :doubled, :integer do
+          public?(true)
+        end
+      end
+
+      identities do
+        identity(:id_unique, [:id])
+      end
+    end
+    """)
+  end
+
+  test "a MATERIALIZED VIEW is NOT generated without --include-views" do
+    AshPostgres.TestRepo.query!("DROP MATERIALIZED VIEW IF EXISTS skip_mv")
+    AshPostgres.TestRepo.query!("DROP TABLE IF EXISTS skip_mv_source")
+
+    AshPostgres.TestRepo.query!("CREATE TABLE skip_mv_source (
+      id UUID DEFAULT uuid_generate_v4() PRIMARY KEY
+    )")
+
+    AshPostgres.TestRepo.query!(
+      "CREATE MATERIALIZED VIEW skip_mv AS SELECT id FROM skip_mv_source"
+    )
+
+    igniter =
+      test_project()
+      |> Igniter.compose_task("ash_postgres.gen.resources", [
+        "MyApp.Accounts",
+        "--tables",
+        "skip_mv",
+        "--yes",
+        "--repo",
+        "AshPostgres.TestRepo"
+      ])
+
+    refute Rewrite.has_source?(igniter.rewrite, "lib/my_app/accounts/skip_mv.ex")
+  end
+
+  test "a VIEW is NOT generated without --include-views" do
+    AshPostgres.TestRepo.query!("DROP VIEW IF EXISTS skip_view")
+    AshPostgres.TestRepo.query!("DROP TABLE IF EXISTS skip_view_source")
+
+    AshPostgres.TestRepo.query!("CREATE TABLE skip_view_source (
+      id UUID DEFAULT uuid_generate_v4() PRIMARY KEY
+    )")
+
+    AshPostgres.TestRepo.query!("CREATE VIEW skip_view AS SELECT id FROM skip_view_source")
+
+    igniter =
+      test_project()
+      |> Igniter.compose_task("ash_postgres.gen.resources", [
+        "MyApp.Accounts",
+        "--tables",
+        "skip_view",
+        "--yes",
+        "--repo",
+        "AshPostgres.TestRepo"
+      ])
+
+    refute Rewrite.has_source?(igniter.rewrite, "lib/my_app/accounts/skip_view.ex")
+  end
+
   test "a resource is generated from a table in a non-public schema with foreign keys and indexes" do
     AshPostgres.TestRepo.query!("CREATE SCHEMA IF NOT EXISTS inventory")
 
@@ -220,14 +412,6 @@ defmodule AshPostgres.ResourceGeenratorTests do
 
       attributes do
         uuid_primary_key :id do
-          public?(true)
-        end
-
-        uuid_primary_key :id do
-          public?(true)
-        end
-
-        attribute :name, :string do
           public?(true)
         end
 
@@ -368,14 +552,6 @@ defmodule AshPostgres.ResourceGeenratorTests do
             public?(true)
           end
 
-          uuid_primary_key :id do
-            public?(true)
-          end
-
-          attribute :name, :string do
-            public?(true)
-          end
-
           attribute :name, :string do
             allow_nil?(false)
             public?(true)
@@ -399,10 +575,6 @@ defmodule AshPostgres.ResourceGeenratorTests do
             public?(true)
           end
 
-          uuid_primary_key :id do
-            public?(true)
-          end
-
           attribute :total, :integer do
             public?(true)
           end
@@ -410,7 +582,6 @@ defmodule AshPostgres.ResourceGeenratorTests do
 
         relationships do
           belongs_to :customer, MyApp.Sales.Customer do
-            allow_nil?(false)
             public?(true)
           end
         end

--- a/test/resource_generator_test.exs
+++ b/test/resource_generator_test.exs
@@ -1067,13 +1067,13 @@ defmodule AshPostgres.ResourceGeenratorTests do
         end
 
         relationships do
-          has_many :reviewer_articles, MyApp.Blog.Article do
-            destination_attribute(:reviewer_id)
+          has_many :author_articles, MyApp.Blog.Article do
+            destination_attribute(:author_id)
             public?(true)
           end
 
-          has_many :author_articles, MyApp.Blog.Article do
-            destination_attribute(:author_id)
+          has_many :reviewer_articles, MyApp.Blog.Article do
+            destination_attribute(:reviewer_id)
             public?(true)
           end
         end

--- a/test/resource_generator_test.exs
+++ b/test/resource_generator_test.exs
@@ -841,6 +841,9 @@ defmodule AshPostgres.ResourceGeenratorTests do
       content = file_content(igniter, "lib/my_app/blog/article_tag.ex")
       assert content =~ "belongs_to :article, MyApp.Blog.Article"
       assert content =~ "belongs_to :topic, MyApp.Blog.Topic"
+      # Composite PK lives on the FK columns; each belongs_to must declare primary_key? true
+      # so Ash recognizes the composite PK and does not raise VerifyPrimaryKeyPresent.
+      assert content =~ "primary_key?(true)"
       refute content =~ "many_to_many"
       refute content =~ "has_many"
     end

--- a/test/resource_generator_test.exs
+++ b/test/resource_generator_test.exs
@@ -67,6 +67,59 @@ defmodule AshPostgres.ResourceGeenratorTests do
     """)
   end
 
+  test "a resource is generated from a table without a primary key" do
+    AshPostgres.TestRepo.query!("DROP TABLE IF EXISTS pk_less_table")
+
+    AshPostgres.TestRepo.query!("CREATE TABLE pk_less_table (
+      name VARCHAR(255),
+      value INTEGER
+    )")
+
+    test_project()
+    |> Igniter.compose_task("ash_postgres.gen.resources", [
+      "MyApp.Accounts",
+      "--tables",
+      "pk_less_table",
+      "--yes",
+      "--repo",
+      "AshPostgres.TestRepo"
+    ])
+    |> assert_creates("lib/my_app/accounts/pk_less_table.ex", """
+    defmodule MyApp.Accounts.PkLessTable do
+      use Ash.Resource,
+        domain: MyApp.Accounts,
+        data_layer: AshPostgres.DataLayer
+
+      resource do
+        # WARNING: Configured to bypass missing primary key.
+        # Add primary_key?: true to your attributes/relationships and remove this block.
+        require_primary_key?(false)
+      end
+
+      actions do
+        # WARNING: No primary key detected.
+        # :update and :destroy actions require a primary key to safely identify records.
+        defaults([:read, create: :*])
+      end
+
+      postgres do
+        table("pk_less_table")
+        repo(AshPostgres.TestRepo)
+      end
+
+      attributes do
+        attribute :name, :string do
+          public?(true)
+        end
+
+        attribute :value, :integer do
+          public?(true)
+        end
+      end
+    end
+    """)
+  end
+
   test "a resource is generated from a table in a non-public schema with foreign keys and indexes" do
     AshPostgres.TestRepo.query!("CREATE SCHEMA IF NOT EXISTS inventory")
 

--- a/test/resource_generator_test.exs
+++ b/test/resource_generator_test.exs
@@ -434,6 +434,47 @@ defmodule AshPostgres.ResourceGeenratorTests do
     """)
   end
 
+  test "resolves has_many name conflicts using suggested names when --yes is set" do
+    AshPostgres.TestRepo.query!("DROP TABLE IF EXISTS conflict_posts CASCADE")
+    AshPostgres.TestRepo.query!("DROP TABLE IF EXISTS conflict_authors CASCADE")
+
+    AshPostgres.TestRepo.query!("""
+    CREATE TABLE conflict_authors (
+      id UUID DEFAULT uuid_generate_v4() PRIMARY KEY,
+      name VARCHAR(255)
+    )
+    """)
+
+    AshPostgres.TestRepo.query!("""
+    CREATE TABLE conflict_posts (
+      id UUID DEFAULT uuid_generate_v4() PRIMARY KEY,
+      title VARCHAR(255),
+      created_by_id UUID REFERENCES conflict_authors(id),
+      updated_by_id UUID REFERENCES conflict_authors(id)
+    )
+    """)
+
+    igniter =
+      test_project()
+      |> Igniter.compose_task("ash_postgres.gen.resources", [
+        "MyApp.Accounts",
+        "--tables",
+        "conflict_authors,conflict_posts",
+        "--yes",
+        "--repo",
+        "AshPostgres.TestRepo"
+      ])
+
+    author_source =
+      Rewrite.source!(igniter.rewrite, "lib/my_app/accounts/conflict_author.ex")
+
+    author_content = Rewrite.Source.get(author_source, :content)
+
+    assert author_content =~ ":created_by_conflict_posts"
+    assert author_content =~ ":updated_by_conflict_posts"
+    refute author_content =~ "has_many :conflict_posts,"
+  end
+
   describe "--fragments option" do
     @describetag :fragments
 


### PR DESCRIPTION
# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [x] Documentation changes
- [x] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies


This PR improves `mix ash_postgres.gen.resources` adding many_to_many detection, views and better conflict resolution. See: https://discordapp.com/channels/711271361523351632/1495458363960721629

I also set up an example project with a legacy DB schema, to test the generator on a real-world schema. https://github.com/weljoda/gen_resources_example

## New capabilities

- many_to_many detection. When a table is a pure join table (two FKs to two distinct tables, identity backed by either a composite primary key or a unique index over both FK columns), the generator now emits a many_to_many on each endpoint alongside the has_many to the join resource.
- PostgreSQL VIEW / MATERIALIZED VIEW support via `--include-views`. View-backed resources are emitted with `migrate? false` and a :read-only default action. The underlying introspection queries were ported from information_schema to pg_catalog so views are discoverable at all.
- Tables without a primary key are now generated with `require_primary_key? false` and a `:read, create: :*` default action, each carrying a # WARNING: comment pointing the user at the fix.
- `--skip-many-to-many` flag for users who prefer just has_many on join tables.

## Conflict-resolution UX overhaul

When multiple FKs produce duplicate default relationship names, the generator now:

- Shows full conflict context (resource, type, destination, FK column, constraint name) and a suggests an alternative name when common naming patterns are detected.
- Offers a menu with the following options: use suggested, auto-resolve remaining on this resource, skip this relationship.
- Tracks a [seen/total] progress counter so you know how many prompts are left per resource.
- Resolves names against existing attributes and previously named relationships, recursing until no collisions remain.

In my usecase this reduced the prompts by using auto-resolve to 4 from 58 previously.

## Bug fixes folded in

- opts[:yes] was being checked as opts[:yes?], so --yes never actually short-circuited the conflict prompts. Fixed.
- add_primary_key/2 was called with a boolean instead of the attribute struct, so its pattern match never fired and composite-PK join tables. Previously the compiler raised an error when generating resources with composite-PK join tables.

## Generated-code ordering

- relationships do now groups by type (belongs_to → has_one → has_many → many_to_many) then alphabetical within each group, instead of all-alphabetical with many_to_many interspersed.
- references do is alphabetical by relationship name, matching the belongs_to order rather than FK-insertion order.