### PR TITLE
fix: handle removal of :context multitenancy in migrations

### DIFF
--- a/lib/migration_generator/migration_generator.ex
+++ b/lib/migration_generator/migration_generator.ex
@@ -3109,32 +3109,22 @@ defmodule AshPostgres.MigrationGenerator do
     not is_nil(Map.get(attribute, :references)) and
       !(attribute.references.multitenancy &&
           attribute.references.multitenancy.strategy == :context &&
-          (is_nil(multitenancy) || multitenancy.strategy == :attribute))
+          (is_nil(multitenancy) || multitenancy.strategy == :attribute)) and
+      !(multitenancy && multitenancy.strategy == :context &&
+          attribute.references.multitenancy &&
+          attribute.references.multitenancy.strategy == :context)
   end
 
-  def get_existing_snapshot(snapshot, opts) do
-    folder = get_snapshot_folder(snapshot, opts)
-    snapshot_path = get_snapshot_path(snapshot, folder)
-
-    if File.exists?(snapshot_path) do
-      snapshot_path
-      |> File.ls!()
-      |> Enum.filter(
-        &(String.match?(&1, ~r/^\d{14}\.json$/) or
-            (opts.dev and String.match?(&1, ~r/^\d{14}\_dev.json$/)))
-      )
-      |> case do
-        [] ->
-          get_old_snapshot(folder, snapshot)
-
-        snapshot_files ->
-          snapshot_path
-          |> Path.join(Enum.max(snapshot_files))
-          |> File.read!()
-          |> load_snapshot()
-      end
+  defp get_alternate_snapshot_folder(snapshot, opts) do
+    if snapshot.multitenancy.strategy == :context do
+      opts
+      |> snapshot_path(snapshot.repo)
+      |> Path.join(repo_name(snapshot.repo))
     else
-      get_old_snapshot(folder, snapshot)
+      opts
+      |> snapshot_path(snapshot.repo)
+      |> Path.join(repo_name(snapshot.repo))
+      |> Path.join("tenants")
     end
   end
 
@@ -3148,6 +3138,64 @@ defmodule AshPostgres.MigrationGenerator do
       opts
       |> snapshot_path(snapshot.repo)
       |> Path.join(repo_name(snapshot.repo))
+    end
+  end
+
+  def get_existing_snapshot(snapshot, opts) do
+    folder = get_snapshot_folder(snapshot, opts)
+    snapshot_path = get_snapshot_path(snapshot, folder)
+
+    result =
+      if File.exists?(snapshot_path) do
+        snapshot_path
+        |> File.ls!()
+        |> Enum.filter(
+          &(String.match?(&1, ~r/^\d{14}\.json$/) or
+              (opts.dev and String.match?(&1, ~r/^\d{14}\_dev.json$/)))
+        )
+        |> case do
+          [] ->
+            get_old_snapshot(folder, snapshot)
+
+          snapshot_files ->
+            snapshot_path
+            |> Path.join(Enum.max(snapshot_files))
+            |> File.read!()
+            |> load_snapshot()
+        end
+      else
+        get_old_snapshot(folder, snapshot)
+      end
+
+    # If no snapshot was found in the primary folder, check the alternate folder.
+    # This handles the case where multitenancy strategy has changed (e.g. :context
+    # to nil/global), which causes the snapshot to be stored in a different folder.
+    if is_nil(result) do
+      alternate_folder = get_alternate_snapshot_folder(snapshot, opts)
+      alternate_path = get_snapshot_path(snapshot, alternate_folder)
+
+      if File.exists?(alternate_path) do
+        alternate_path
+        |> File.ls!()
+        |> Enum.filter(
+          &(String.match?(&1, ~r/^\d{14}\.json$/) or
+              (opts.dev and String.match?(&1, ~r/^\d{14}\_dev.json$/)))
+        )
+        |> case do
+          [] ->
+            get_old_snapshot(alternate_folder, snapshot)
+
+          snapshot_files ->
+            alternate_path
+            |> Path.join(Enum.max(snapshot_files))
+            |> File.read!()
+            |> load_snapshot()
+        end
+      else
+        get_old_snapshot(alternate_folder, snapshot)
+      end
+    else
+      result
     end
   end
 

--- a/lib/migration_generator/migration_generator.ex
+++ b/lib/migration_generator/migration_generator.ex
@@ -3115,85 +3115,62 @@ defmodule AshPostgres.MigrationGenerator do
           attribute.references.multitenancy.strategy == :context)
   end
 
-  defp get_alternate_snapshot_folder(snapshot, opts) do
+  defp get_snapshot_folder(snapshot, opts) do
+    base =
+      opts
+      |> snapshot_path(snapshot.repo)
+      |> Path.join(repo_name(snapshot.repo))
+
     if snapshot.multitenancy.strategy == :context do
-      opts
-      |> snapshot_path(snapshot.repo)
-      |> Path.join(repo_name(snapshot.repo))
+      Path.join(base, "tenants")
     else
-      opts
-      |> snapshot_path(snapshot.repo)
-      |> Path.join(repo_name(snapshot.repo))
-      |> Path.join("tenants")
+      base
     end
   end
 
-  defp get_snapshot_folder(snapshot, opts) do
+  defp get_alternate_snapshot_folder(snapshot, opts) do
+    base =
+      opts
+      |> snapshot_path(snapshot.repo)
+      |> Path.join(repo_name(snapshot.repo))
+
     if snapshot.multitenancy.strategy == :context do
-      opts
-      |> snapshot_path(snapshot.repo)
-      |> Path.join(repo_name(snapshot.repo))
-      |> Path.join("tenants")
+      base
     else
-      opts
-      |> snapshot_path(snapshot.repo)
-      |> Path.join(repo_name(snapshot.repo))
+      Path.join(base, "tenants")
+    end
+  end
+
+  defp load_snapshot_from_folder(folder, snapshot, opts) do
+    snapshot_path = get_snapshot_path(snapshot, folder)
+
+    if File.exists?(snapshot_path) do
+      snapshot_path
+      |> File.ls!()
+      |> Enum.filter(
+        &(String.match?(&1, ~r/^\d{14}\.json$/) or
+            (opts.dev and String.match?(&1, ~r/^\d{14}\_dev.json$/)))
+      )
+      |> case do
+        [] ->
+          get_old_snapshot(folder, snapshot)
+
+        snapshot_files ->
+          snapshot_path
+          |> Path.join(Enum.max(snapshot_files))
+          |> File.read!()
+          |> load_snapshot()
+      end
+    else
+      get_old_snapshot(folder, snapshot)
     end
   end
 
   def get_existing_snapshot(snapshot, opts) do
-    folder = get_snapshot_folder(snapshot, opts)
-    snapshot_path = get_snapshot_path(snapshot, folder)
+    result = load_snapshot_from_folder(get_snapshot_folder(snapshot, opts), snapshot, opts)
 
-    result =
-      if File.exists?(snapshot_path) do
-        snapshot_path
-        |> File.ls!()
-        |> Enum.filter(
-          &(String.match?(&1, ~r/^\d{14}\.json$/) or
-              (opts.dev and String.match?(&1, ~r/^\d{14}\_dev.json$/)))
-        )
-        |> case do
-          [] ->
-            get_old_snapshot(folder, snapshot)
-
-          snapshot_files ->
-            snapshot_path
-            |> Path.join(Enum.max(snapshot_files))
-            |> File.read!()
-            |> load_snapshot()
-        end
-      else
-        get_old_snapshot(folder, snapshot)
-      end
-
-    # If no snapshot was found in the primary folder, check the alternate folder.
-    # This handles the case where multitenancy strategy has changed (e.g. :context
-    # to nil/global), which causes the snapshot to be stored in a different folder.
     if is_nil(result) do
-      alternate_folder = get_alternate_snapshot_folder(snapshot, opts)
-      alternate_path = get_snapshot_path(snapshot, alternate_folder)
-
-      if File.exists?(alternate_path) do
-        alternate_path
-        |> File.ls!()
-        |> Enum.filter(
-          &(String.match?(&1, ~r/^\d{14}\.json$/) or
-              (opts.dev and String.match?(&1, ~r/^\d{14}\_dev.json$/)))
-        )
-        |> case do
-          [] ->
-            get_old_snapshot(alternate_folder, snapshot)
-
-          snapshot_files ->
-            alternate_path
-            |> Path.join(Enum.max(snapshot_files))
-            |> File.read!()
-            |> load_snapshot()
-        end
-      else
-        get_old_snapshot(alternate_folder, snapshot)
-      end
+      load_snapshot_from_folder(get_alternate_snapshot_folder(snapshot, opts), snapshot, opts)
     else
       result
     end


### PR DESCRIPTION
# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [X ] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies


When a resource transitions from :context multitenancy to global?: true (or removing multitenancy entirely), the migration generator produces an invalid migration that tries to drop a foreign key constraint that doesn't exist yet.

# Bugs:

1. Wrong snapshot folder lookup - :context snapshots are stored in tenants/ but after removing multitenancy the code looks in the base folder. The old snapshot is not found so the table is treated as brand new.

2. Incorrect FK drop generated - has_reference?/2 did not account for the case where both the table and the referenced resource previously had :context multitenancy. Since the FK was never created in the global schema, it should not be dropped.

# Fix: 
1. get_existing_snapshot/2: fall back to checking the alternate folder when the primary lookup returns nil.
2. has_reference?/2: return false when both multitenancy strategies are :context, since no global FK exists to drop.


# Testing
Reproduced using the demo repo linked in the issue: https://github.com/serpent213/ash_postgres_multitenancy_migration_demo

After the fix, all three steps complete successfully:
1. mix ash.reset
2.  mix ash_postgres.generate_migrations --dev
3.  mix ash.migrate