### PR TITLE
Commit for specifying global vs tenant statements

### DIFF
--- a/documentation/dsls/DSL-AshPostgres.DataLayer.md
+++ b/documentation/dsls/DSL-AshPostgres.DataLayer.md
@@ -196,6 +196,7 @@ end
 | [`up`](#postgres-custom_statements-statement-up){: #postgres-custom_statements-statement-up .spark-required} | `String.t` |  | How to create the structure of the statement |
 | [`down`](#postgres-custom_statements-statement-down){: #postgres-custom_statements-statement-down .spark-required} | `String.t` |  | How to tear down the structure of the statement |
 | [`code?`](#postgres-custom_statements-statement-code?){: #postgres-custom_statements-statement-code? } | `boolean` | `false` | By default, we place the strings inside of ecto migration's `execute/1` function and assume they are sql. Use this option if you want to provide custom elixir code to be placed directly in the migrations |
+| [`global?`](#postgres-custom_statements-statement-global?){: #postgres-custom_statements-statement-global? } | `boolean` | `false` | By default, a multi-tenant resource's custom statements will be written into the tenant migration folder. Set this to true for statements that create global, shared structures so they are written into the public migration folder even when defined on a tenant resource. |
 
 
 

--- a/lib/migration_generator/migration_generator.ex
+++ b/lib/migration_generator/migration_generator.ex
@@ -510,31 +510,24 @@ defmodule AshPostgres.MigrationGenerator do
             end
           end
 
-          if opts.snapshots_only do
-            []
-          else
-            operations
-            |> split_into_migrations()
-            |> Enum.with_index()
-            |> Enum.map(fn {operations, split_index} ->
-              run_without_transaction? =
-                Enum.any?(operations, fn
-                  %Operation.AddCustomIndex{index: %{concurrently: true}} ->
-                    true
+          {tenant_operations, public_operations} =
+            if tenant? do
+              public_ops = Enum.filter(operations, &public_custom_statement_operation?/1)
+              tenant_ops = Enum.reject(operations, &public_custom_statement_operation?/1)
+              {tenant_ops, public_ops}
+            else
+              {operations, []}
+            end
 
-                  %Operation.AddUniqueIndex{concurrently: true} ->
-                    true
+          migrations =
+            if opts.snapshots_only do
+              []
+            else
+              operations_to_migrations(tenant_operations, repo, opts, tenant?) ++
+                operations_to_migrations(public_operations, repo, opts, false)
+            end
 
-                  _ ->
-                    false
-                end)
-
-              operations
-              |> organize_operations()
-              |> build_up_and_down()
-              |> migration(repo, opts, tenant?, run_without_transaction?, split_index)
-            end)
-          end
+          migrations
           |> Enum.concat(create_new_snapshot(snapshots, repo_name(repo), opts, tenant?))
           |> then(fn files ->
             remove_orphan_snapshots(orphan_snapshots, opts)
@@ -543,6 +536,44 @@ defmodule AshPostgres.MigrationGenerator do
       end
     end)
   end
+
+  defp operations_to_migrations([], _repo, _opts, _tenant?), do: []
+
+  defp operations_to_migrations(operations, repo, opts, tenant?) do
+    operations
+    |> split_into_migrations()
+    |> Enum.with_index()
+    |> Enum.map(fn {operations, split_index} ->
+      run_without_transaction? =
+        Enum.any?(operations, fn
+          %Operation.AddCustomIndex{index: %{concurrently: true}} ->
+            true
+
+          %Operation.AddUniqueIndex{concurrently: true} ->
+            true
+
+          _ ->
+            false
+        end)
+
+      operations
+      |> organize_operations()
+      |> build_up_and_down()
+      |> migration(repo, opts, tenant?, run_without_transaction?, split_index)
+    end)
+  end
+
+  defp public_custom_statement_operation?(%Operation.AddCustomStatement{
+         statement: %{global?: true}
+       }),
+       do: true
+
+  defp public_custom_statement_operation?(%Operation.RemoveCustomStatement{
+         statement: %{global?: true}
+       }),
+       do: true
+
+  defp public_custom_statement_operation?(_), do: false
 
   defp get_dev_migrations(opts, tenant?, repo) do
     opts
@@ -4310,7 +4341,9 @@ defmodule AshPostgres.MigrationGenerator do
 
   defp load_custom_statements(statements) do
     Enum.map(statements || [], fn statement ->
-      Map.update!(statement, :name, &maybe_to_atom/1)
+      statement
+      |> Map.update!(:name, &maybe_to_atom/1)
+      |> Map.put_new(:global?, false)
     end)
   end
 

--- a/lib/statement.ex
+++ b/lib/statement.ex
@@ -9,7 +9,8 @@ defmodule AshPostgres.Statement do
     :name,
     :up,
     :down,
-    :code?
+    :code?,
+    :global?
   ]
 
   defstruct @fields ++ [:__spark_metadata__]
@@ -29,6 +30,13 @@ defmodule AshPostgres.Statement do
       default: false,
       doc: """
       By default, we place the strings inside of ecto migration's `execute/1` function and assume they are sql. Use this option if you want to provide custom elixir code to be placed directly in the migrations
+      """
+    ],
+    global?: [
+      type: :boolean,
+      default: false,
+      doc: """
+      By default, a multi-tenant resource's custom statements will be written into the tenant migration folder. Set this to true for statements that create global, shared structures so they are written into the public migration folder even when defined on a tenant resource.
       """
     ],
     up: [


### PR DESCRIPTION
# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [x] Documentation changes
- [ ] Features include unit/acceptance tests
- [x] Refactoring
- [ ] Update dependencies



# issue #538 proposed solution

Certain custom statements, specifically custom enum types, become part of the tenant migration and fail to execute as they create a duplicate table. This should instead become global for the database instead. Manual intervention was a workaround needed for this. The solution is to add a configuration.

DataLayer.md:
Line 199:  provides documentation for the new configuration boolean.

statement.ex:
Line 13: Add the new configuration
Lines 35-41: Add the behavior for the configuration. This is set default to false to allow normal behavior and backwards compatibility. 

migration_generator.ex:
Lines 513-577: Modified the tenant operations to still allow normal behavior with the new configuration, and then the configuration assists in deciding if the file should be sent to the tenant or have public access.

Lines 4313, 4344-4346: Edit the JSON storage of the custom statement to include the new configuration, this way it is not lost on storage and retrieval.