### PR TITLE
Fix/move table schema migrations

### DIFF
--- a/lib/migration_generator/migration_generator.ex
+++ b/lib/migration_generator/migration_generator.ex
@@ -489,10 +489,25 @@ defmodule AshPostgres.MigrationGenerator do
         Enum.map(deduped, fn {%{table: table, schema: schema} = snapshot, existing_snapshot} ->
           cond do
             move_info = Map.get(schema_move_map, {table, schema}) ->
-              {snapshot, move_info.snapshot}
+              if move_info[:declined?] do
+                {snapshot, nil}
+              else
+                {snapshot, move_info.snapshot}
+              end
 
             rename_info = Map.get(rename_map, {table, schema}) ->
               {snapshot, rename_info.snapshot}
+
+            existing_snapshot && existing_snapshot.schema != schema ->
+              if moving_table_to_schema?(
+                   {table, existing_snapshot.schema},
+                   {table, schema},
+                   opts
+                 ) do
+                {snapshot, existing_snapshot}
+              else
+                {snapshot, nil}
+              end
 
             true ->
               {snapshot, existing_snapshot}
@@ -3524,13 +3539,33 @@ defmodule AshPostgres.MigrationGenerator do
               {ops, rename_map, schema_move_map, snapshots} =
                 case schema_move_candidates do
                   [{new_table, new_schema}] ->
-                    new_schema_move_map =
-                      Map.put(schema_move_map, {new_table, new_schema}, %{
-                        old_schema: schema,
-                        snapshot: existing_snapshot
-                      })
+                    if moving_table_to_schema?(old_key, {new_table, new_schema}, opts) do
+                      new_schema_move_map =
+                        Map.put(schema_move_map, {new_table, new_schema}, %{
+                          old_schema: schema,
+                          snapshot: existing_snapshot
+                        })
 
-                    {ops, rename_map, new_schema_move_map, [existing_snapshot | snapshots]}
+                      {ops, rename_map, new_schema_move_map, [existing_snapshot | snapshots]}
+                    else
+                      declined_schema_move_map =
+                        Map.put(schema_move_map, {new_table, new_schema}, %{declined?: true})
+
+                      if drop_table_confirmed?(existing_snapshot, opts) do
+                        drop_op = %Operation.DropTable{
+                          table: existing_snapshot.table,
+                          schema: existing_snapshot.schema,
+                          repo: existing_snapshot.repo,
+                          multitenancy: existing_snapshot.multitenancy
+                        }
+
+                        {[drop_op | ops], rename_map, declined_schema_move_map,
+                         [existing_snapshot | snapshots]}
+                      else
+                        record_drop_table_opt_out(existing_snapshot, opts)
+                        {ops, rename_map, declined_schema_move_map, snapshots}
+                      end
+                    end
 
                   _ ->
                     case rename_candidates do
@@ -3785,6 +3820,24 @@ defmodule AshPostgres.MigrationGenerator do
       end
     end
   end
+
+  defp moving_table_to_schema?({table, old_schema}, {_new_table, new_schema}, opts) do
+    if opts.dev do
+      false
+    else
+      message =
+        "Are you moving #{schema_table_name(table, old_schema)} to #{schema_table_name(table, new_schema)}?"
+
+      if opts.no_shell? do
+        raise "Unimplemented: cannot determine: #{message} without shell input"
+      else
+        yes?(opts, message)
+      end
+    end
+  end
+
+  defp schema_table_name(table, nil), do: table
+  defp schema_table_name(table, schema), do: "#{schema}.#{table}"
 
   defp get_new_attribute(adding, opts, tries \\ 3)
 

--- a/lib/migration_generator/migration_generator.ex
+++ b/lib/migration_generator/migration_generator.ex
@@ -476,7 +476,7 @@ defmodule AshPostgres.MigrationGenerator do
 
       current_table_keys = MapSet.union(managed_table_keys, unmanaged_table_keys)
 
-      {drop_operations, orphan_snapshots, rename_map} =
+      {drop_operations, orphan_snapshots, rename_map, schema_move_map} =
         drop_operations_for_orphan_tables(
           repo,
           current_table_keys,
@@ -485,19 +485,22 @@ defmodule AshPostgres.MigrationGenerator do
           tenant?
         )
 
-      deduped_with_renames =
+      deduped_with_snapshot_matches =
         Enum.map(deduped, fn {%{table: table, schema: schema} = snapshot, existing_snapshot} ->
-          case Map.get(rename_map, {table, schema}) do
-            nil ->
-              {snapshot, existing_snapshot}
+          cond do
+            move_info = Map.get(schema_move_map, {table, schema}) ->
+              {snapshot, move_info.snapshot}
 
-            %{snapshot: old_snapshot} ->
-              {snapshot, old_snapshot}
+            rename_info = Map.get(rename_map, {table, schema}) ->
+              {snapshot, rename_info.snapshot}
+
+            true ->
+              {snapshot, existing_snapshot}
           end
         end)
 
       snapshots_with_operations =
-        deduped_with_renames
+        deduped_with_snapshot_matches
         |> fetch_operations(opts)
         |> Enum.map(&add_order_to_operations/1)
 
@@ -2300,17 +2303,42 @@ defmodule AshPostgres.MigrationGenerator do
   defp after?(_, %Operation.DropTable{}), do: true
   defp after?(%Operation.DropTable{}, _), do: false
 
+  defp after?(
+         %{table: table, schema: schema},
+         %Operation.MoveTableSchema{table: table, schema: schema}
+       ),
+       do: true
+
+  defp after?(%Operation.MoveTableSchema{}, _), do: false
+
   defp after?(_, _), do: false
 
   defp fetch_operations(snapshots, opts) do
+    # Reference diffs need to know when a prefix change is caused by moving
+    # the referenced table instead of by changing the foreign key itself.
+    schema_moves =
+      snapshots
+      |> Enum.flat_map(fn
+        {%{table: table, schema: new_schema}, %{schema: old_schema}}
+        when new_schema != old_schema ->
+          [{table, schema_key(old_schema), schema_key(new_schema)}]
+
+        _ ->
+          []
+      end)
+      |> MapSet.new()
+
     snapshots
     |> Enum.map(fn {snapshot, existing_snapshot} ->
-      {snapshot, do_fetch_operations(snapshot, existing_snapshot, opts)}
+      {snapshot, do_fetch_operations(snapshot, existing_snapshot, opts, [], schema_moves)}
     end)
     |> Enum.reject(fn {_, ops} ->
       Enum.empty?(ops)
     end)
   end
+
+  defp schema_key(nil), do: "public"
+  defp schema_key(schema), do: schema
 
   defp resource_has_meaningful_content?(snapshot) do
     [
@@ -2323,19 +2351,42 @@ defmodule AshPostgres.MigrationGenerator do
     |> Enum.any?(&Enum.any?/1)
   end
 
-  defp do_fetch_operations(snapshot, existing_snapshot, opts, acc \\ [])
+  defp do_fetch_operations(
+         snapshot,
+         existing_snapshot,
+         opts,
+         acc,
+         schema_moves
+       )
 
   defp do_fetch_operations(
          %{schema: new_schema} = snapshot,
-         %{schema: old_schema},
+         %{schema: old_schema} = old_snapshot,
          opts,
-         []
+         [],
+         schema_moves
        )
        when new_schema != old_schema do
-    do_fetch_operations(snapshot, nil, opts, [])
+    # Preserve the old snapshot so schema changes become ALTER TABLE SET SCHEMA
+    # plus any real diffs, instead of create-table from an empty snapshot.
+    do_fetch_operations(
+      snapshot,
+      old_snapshot,
+      opts,
+      [
+        %Operation.MoveTableSchema{
+          table: snapshot.table,
+          schema: new_schema,
+          old_schema: old_schema,
+          new_schema: new_schema,
+          repo: snapshot.repo
+        }
+      ],
+      schema_moves
+    )
   end
 
-  defp do_fetch_operations(snapshot, nil, opts, acc) do
+  defp do_fetch_operations(snapshot, nil, opts, acc, schema_moves) do
     if resource_has_meaningful_content?(snapshot) do
       empty_snapshot = %{
         attributes: [],
@@ -2355,17 +2406,23 @@ defmodule AshPostgres.MigrationGenerator do
         }
       }
 
-      do_fetch_operations(snapshot, empty_snapshot, opts, [
-        %Operation.CreateTable{
-          table: snapshot.table,
-          schema: snapshot.schema,
-          repo: snapshot.repo,
-          multitenancy: snapshot.multitenancy,
-          old_multitenancy: empty_snapshot.multitenancy,
-          create_table_options: snapshot.create_table_options
-        }
-        | acc
-      ])
+      do_fetch_operations(
+        snapshot,
+        empty_snapshot,
+        opts,
+        [
+          %Operation.CreateTable{
+            table: snapshot.table,
+            schema: snapshot.schema,
+            repo: snapshot.repo,
+            multitenancy: snapshot.multitenancy,
+            old_multitenancy: empty_snapshot.multitenancy,
+            create_table_options: snapshot.create_table_options
+          }
+          | acc
+        ],
+        schema_moves
+      )
     else
       if !opts.quiet do
         Logger.info(
@@ -2377,8 +2434,8 @@ defmodule AshPostgres.MigrationGenerator do
     end
   end
 
-  defp do_fetch_operations(snapshot, old_snapshot, opts, acc) do
-    attribute_operations = attribute_operations(snapshot, old_snapshot, opts)
+  defp do_fetch_operations(snapshot, old_snapshot, opts, acc, schema_moves) do
+    attribute_operations = attribute_operations(snapshot, old_snapshot, opts, schema_moves)
 
     {pkey_operations, attribute_operations} =
       pkey_operations(snapshot, old_snapshot, attribute_operations, opts)
@@ -2599,7 +2656,9 @@ defmodule AshPostgres.MigrationGenerator do
         _ -> true
       end)
 
+    # Schema moves must run before operations rendered against the new schema.
     [
+      acc,
       pkey_operations,
       unique_indexes_to_remove,
       creates_and_adds,
@@ -2614,8 +2673,7 @@ defmodule AshPostgres.MigrationGenerator do
       custom_indexes_to_remove,
       custom_statements_to_add,
       custom_statements_to_remove,
-      custom_statements_to_alter,
-      acc
+      custom_statements_to_alter
     ]
     |> Enum.concat()
     |> Enum.map(&Map.put(&1, :multitenancy, snapshot.multitenancy))
@@ -2838,7 +2896,7 @@ defmodule AshPostgres.MigrationGenerator do
     end
   end
 
-  defp attribute_operations(snapshot, old_snapshot, opts) do
+  defp attribute_operations(snapshot, old_snapshot, opts, schema_moves) do
     attributes_to_add =
       Enum.reject(snapshot.attributes, fn attribute ->
         Enum.find(old_snapshot.attributes, &(&1.source == attribute.source))
@@ -2873,7 +2931,8 @@ defmodule AshPostgres.MigrationGenerator do
                  snapshot.repo,
                  old_snapshot,
                  snapshot,
-                 not is_nil(renaming_to_source)
+                 not is_nil(renaming_to_source),
+                 schema_moves
                )
              end
            end
@@ -2968,7 +3027,7 @@ defmodule AshPostgres.MigrationGenerator do
           end
 
         if Map.get(old_attribute, :references) != Map.get(new_attribute, :references) and
-             references_differ_beyond_index?(old_attribute, new_attribute) do
+             references_differ_beyond_index?(old_attribute, new_attribute, schema_moves) do
           redo_deferrability =
             if has_reference?(old_snapshot.multitenancy, old_attribute) and
                  differently_deferrable?(new_attribute, old_attribute) do
@@ -3079,7 +3138,7 @@ defmodule AshPostgres.MigrationGenerator do
   # When the only reference change is index? (add/remove index), we should not emit
   # DropForeignKey + AlterAttribute; the separate AddReferenceIndex/RemoveReferenceIndex
   # operations handle it. This avoids migrations that drop and re-add the same FK.
-  defp references_differ_beyond_index?(old_attr, new_attr) do
+  defp references_differ_beyond_index?(old_attr, new_attr, schema_moves) do
     old_refs = Map.get(old_attr, :references)
     new_refs = Map.get(new_attr, :references)
 
@@ -3091,18 +3150,48 @@ defmodule AshPostgres.MigrationGenerator do
         true
 
       true ->
-        old_without_index = Map.delete(old_refs, :index?)
-        new_without_index = Map.delete(new_refs, :index?)
+        # Ignore the reference prefix when it only changed because the target
+        # table moved schemas; Postgres keeps the FK attached to that table.
+        {old_refs, new_refs} =
+          normalize_reference_schema_move(old_refs, new_refs, schema_moves)
+
+        old_without_index =
+          old_refs
+          |> clean_references_for_comparison()
+          |> Map.delete(:index?)
+
+        new_without_index =
+          new_refs
+          |> clean_references_for_comparison()
+          |> Map.delete(:index?)
+
         old_without_index != new_without_index
     end
   end
 
+  defp clean_references_for_comparison(references) do
+    Map.drop(references, [:destination_attribute_default, :destination_attribute_generated])
+  end
+
   # This exists to handle the fact that the remapping of the key name -> source caused attributes
   # to be considered unequal. We ignore things that only differ in that way using this function.
-  defp attributes_unequal?(left, right, repo, _old_snapshot, _new_snapshot, ignore_names?) do
+  defp attributes_unequal?(
+         left,
+         right,
+         repo,
+         _old_snapshot,
+         _new_snapshot,
+         ignore_names?,
+         schema_moves
+       ) do
     left = clean_for_equality(left, repo)
 
     right = clean_for_equality(right, repo)
+
+    # A relationship field should not look altered just because the referenced
+    # table moved schemas in the same migration.
+    {left, right} =
+      normalize_attribute_reference_schema_move(left, right, schema_moves)
 
     left =
       if ignore_names? do
@@ -3120,6 +3209,43 @@ defmodule AshPostgres.MigrationGenerator do
 
     left != right
   end
+
+  defp normalize_attribute_reference_schema_move(left, right, schema_moves) do
+    old_refs = Map.get(left, :references)
+    new_refs = Map.get(right, :references)
+
+    if reference_schema_move?(old_refs, new_refs, schema_moves) do
+      {
+        Map.update!(left, :references, &Map.delete(&1, :schema)),
+        Map.update!(right, :references, &Map.delete(&1, :schema))
+      }
+    else
+      {left, right}
+    end
+  end
+
+  defp normalize_reference_schema_move(old_refs, new_refs, schema_moves) do
+    if reference_schema_move?(old_refs, new_refs, schema_moves) do
+      {Map.delete(old_refs, :schema), Map.delete(new_refs, :schema)}
+    else
+      {old_refs, new_refs}
+    end
+  end
+
+  defp reference_schema_move?(
+         %{table: table, schema: old_schema},
+         %{table: table, schema: new_schema},
+         schema_moves
+       ) do
+    old_schema = schema_key(old_schema)
+    new_schema = schema_key(new_schema)
+
+    Enum.any?([table, to_string(table)], fn table ->
+      MapSet.member?(schema_moves, {table, old_schema, new_schema})
+    end)
+  end
+
+  defp reference_schema_move?(_, _, _), do: false
 
   defp clean_for_equality(attribute, repo) do
     cond do
@@ -3364,9 +3490,10 @@ defmodule AshPostgres.MigrationGenerator do
         %{strategy: nil, attribute: nil, global: nil}
       end
 
-    {drop_ops, rename_map, loaded} =
-      Enum.reduce(orphan_keys, {[], %{}, []}, fn {table, schema} = old_key,
-                                                 {ops, rename_map, snapshots} ->
+    {drop_ops, rename_map, schema_move_map, loaded} =
+      Enum.reduce(orphan_keys, {[], %{}, %{}, []}, fn {table, schema} = old_key,
+                                                      {ops, rename_map, schema_move_map,
+                                                       snapshots} ->
         minimal_snapshot = %{
           table: table,
           schema: schema,
@@ -3376,63 +3503,83 @@ defmodule AshPostgres.MigrationGenerator do
 
         case get_existing_snapshot(minimal_snapshot, opts) do
           nil ->
-            {ops, rename_map, snapshots}
+            {ops, rename_map, schema_move_map, snapshots}
 
           existing_snapshot ->
             if Map.get(existing_snapshot, :drop_table_opted_out, false) do
-              {ops, rename_map, snapshots}
+              {ops, rename_map, schema_move_map, snapshots}
             else
-              # Only consider new tables in the same schema as candidates
-              candidates =
+              # Infer one same-table/different-schema candidate as an intentional schema move.
+              schema_move_candidates =
+                Enum.filter(added_keys_list, fn {new_table, new_schema} ->
+                  new_table == table && new_schema != schema
+                end)
+
+              # Only consider new tables in the same schema as rename candidates
+              rename_candidates =
                 Enum.filter(added_keys_list, fn {new_table, new_schema} ->
                   new_schema == schema && new_table != table
                 end)
 
-              {ops, rename_map, snapshots} =
-                case candidates do
+              {ops, rename_map, schema_move_map, snapshots} =
+                case schema_move_candidates do
                   [{new_table, new_schema}] ->
-                    if renaming_table_to?(old_key, {new_table, new_schema}, opts) do
-                      new_rename_map =
-                        Map.put(rename_map, {new_table, new_schema}, %{
-                          old_table: table,
-                          old_schema: schema,
-                          snapshot: existing_snapshot
-                        })
+                    new_schema_move_map =
+                      Map.put(schema_move_map, {new_table, new_schema}, %{
+                        old_schema: schema,
+                        snapshot: existing_snapshot
+                      })
 
-                      {ops, new_rename_map, [existing_snapshot | snapshots]}
-                    else
-                      if drop_table_confirmed?(existing_snapshot, opts) do
-                        drop_op = %Operation.DropTable{
-                          table: existing_snapshot.table,
-                          schema: existing_snapshot.schema,
-                          repo: existing_snapshot.repo,
-                          multitenancy: existing_snapshot.multitenancy
-                        }
-
-                        {[drop_op | ops], rename_map, [existing_snapshot | snapshots]}
-                      else
-                        record_drop_table_opt_out(existing_snapshot, opts)
-                        {ops, rename_map, snapshots}
-                      end
-                    end
+                    {ops, rename_map, new_schema_move_map, [existing_snapshot | snapshots]}
 
                   _ ->
-                    if drop_table_confirmed?(existing_snapshot, opts) do
-                      drop_op = %Operation.DropTable{
-                        table: existing_snapshot.table,
-                        schema: existing_snapshot.schema,
-                        repo: existing_snapshot.repo,
-                        multitenancy: existing_snapshot.multitenancy
-                      }
+                    case rename_candidates do
+                      [{new_table, new_schema}] ->
+                        if renaming_table_to?(old_key, {new_table, new_schema}, opts) do
+                          new_rename_map =
+                            Map.put(rename_map, {new_table, new_schema}, %{
+                              old_table: table,
+                              old_schema: schema,
+                              snapshot: existing_snapshot
+                            })
 
-                      {[drop_op | ops], rename_map, [existing_snapshot | snapshots]}
-                    else
-                      record_drop_table_opt_out(existing_snapshot, opts)
-                      {ops, rename_map, snapshots}
+                          {ops, new_rename_map, schema_move_map, [existing_snapshot | snapshots]}
+                        else
+                          if drop_table_confirmed?(existing_snapshot, opts) do
+                            drop_op = %Operation.DropTable{
+                              table: existing_snapshot.table,
+                              schema: existing_snapshot.schema,
+                              repo: existing_snapshot.repo,
+                              multitenancy: existing_snapshot.multitenancy
+                            }
+
+                            {[drop_op | ops], rename_map, schema_move_map,
+                             [existing_snapshot | snapshots]}
+                          else
+                            record_drop_table_opt_out(existing_snapshot, opts)
+                            {ops, rename_map, schema_move_map, snapshots}
+                          end
+                        end
+
+                      _ ->
+                        if drop_table_confirmed?(existing_snapshot, opts) do
+                          drop_op = %Operation.DropTable{
+                            table: existing_snapshot.table,
+                            schema: existing_snapshot.schema,
+                            repo: existing_snapshot.repo,
+                            multitenancy: existing_snapshot.multitenancy
+                          }
+
+                          {[drop_op | ops], rename_map, schema_move_map,
+                           [existing_snapshot | snapshots]}
+                        else
+                          record_drop_table_opt_out(existing_snapshot, opts)
+                          {ops, rename_map, schema_move_map, snapshots}
+                        end
                     end
                 end
 
-              {ops, rename_map, snapshots}
+              {ops, rename_map, schema_move_map, snapshots}
             end
         end
       end)
@@ -3440,7 +3587,7 @@ defmodule AshPostgres.MigrationGenerator do
     loaded = Enum.reverse(loaded)
     drop_ops = Enum.reverse(drop_ops)
 
-    {sort_drop_table_operations(drop_ops, loaded), loaded, rename_map}
+    {sort_drop_table_operations(drop_ops, loaded), loaded, rename_map, schema_move_map}
   end
 
   defp sort_drop_table_operations(drop_ops, snapshots) do

--- a/lib/migration_generator/operation.ex
+++ b/lib/migration_generator/operation.ex
@@ -210,6 +210,52 @@ defmodule AshPostgres.MigrationGenerator.Operation do
     end
   end
 
+  defmodule MoveTableSchema do
+    @moduledoc false
+    defstruct [:table, :schema, :old_schema, :new_schema, :repo, :multitenancy, no_phase: true]
+
+    def up(%{table: table, old_schema: old_schema, new_schema: new_schema, repo: repo}) do
+      # Moving into a configured schema may require creating it first.
+      create_schema =
+        if new_schema && repo.create_schemas_in_migrations?() do
+          "execute(\"CREATE SCHEMA IF NOT EXISTS #{new_schema}\")\n\n"
+        else
+          ""
+        end
+
+      create_schema <> move_schema_statement(table, old_schema, new_schema)
+    end
+
+    def down(%{table: table, old_schema: old_schema, new_schema: new_schema}) do
+      move_schema_statement(table, new_schema, old_schema)
+    end
+
+    defp move_schema_statement(table, from_schema, to_schema) do
+      # A nil Ash schema means Postgres' default public schema.
+      target_schema = to_schema || "public"
+
+      sql =
+        "ALTER TABLE #{qualified_table_name(table, from_schema)} SET SCHEMA #{quoted_identifier(target_schema)}"
+
+      "execute(#{inspect(sql)})"
+    end
+
+    defp qualified_table_name(table, nil), do: quoted_identifier(table)
+
+    defp qualified_table_name(table, schema) do
+      "#{quoted_identifier(schema)}.#{quoted_identifier(table)}"
+    end
+
+    defp quoted_identifier(identifier) do
+      escaped =
+        identifier
+        |> to_string()
+        |> String.replace(~s("), ~s(""))
+
+      ~s("#{escaped}")
+    end
+  end
+
   defmodule AddAttribute do
     @moduledoc false
     defstruct [:attribute, :table, :schema, :multitenancy, :old_multitenancy]

--- a/test/migration_generator_test.exs
+++ b/test/migration_generator_test.exs
@@ -5364,5 +5364,348 @@ defmodule AshPostgres.MigrationGeneratorTest do
       assert latest =~
                ~S[rename table(:schema_messages_rename, prefix: "my_schema_rename"), to: table(:schema_messages_rename_new, prefix: "my_schema_rename")]
     end
+
+    test "generates alter table set schema when a resource schema is added", %{
+      snapshot_path: snapshot_path,
+      migration_path: migration_path
+    } do
+      defresource SchemaMoveMessage, "schema_move_messages" do
+        attributes do
+          uuid_primary_key(:id)
+          attribute(:body, :string, public?: true)
+        end
+
+        actions do
+          defaults([:create, :read, :update, :destroy])
+        end
+      end
+
+      defdomain([SchemaMoveMessage])
+
+      AshPostgres.MigrationGenerator.generate(Domain,
+        snapshot_path: snapshot_path,
+        migration_path: migration_path,
+        quiet: true,
+        format: false,
+        auto_name: true,
+        name: "add_schema_move_messages"
+      )
+
+      defresource SchemaMoveMessage, "schema_move_messages" do
+        postgres do
+          table "schema_move_messages"
+          schema "moved_messages"
+          repo(AshPostgres.TestRepo)
+        end
+
+        attributes do
+          uuid_primary_key(:id)
+          attribute(:body, :string, public?: true)
+        end
+
+        actions do
+          defaults([:create, :read, :update, :destroy])
+        end
+      end
+
+      defdomain([SchemaMoveMessage])
+
+      AshPostgres.MigrationGenerator.generate(Domain,
+        snapshot_path: snapshot_path,
+        migration_path: migration_path,
+        quiet: true,
+        format: false,
+        auto_name: true,
+        name: "move_messages_schema"
+      )
+
+      migration_files =
+        Path.wildcard("#{migration_path}/**/*.exs")
+        |> Enum.reject(&String.contains?(&1, "extensions"))
+        |> Enum.sort()
+
+      latest =
+        migration_files
+        |> List.last()
+        |> File.read!()
+
+      assert latest =~ ~S[execute("CREATE SCHEMA IF NOT EXISTS moved_messages")]
+
+      assert latest =~
+               ~S[execute("ALTER TABLE \"schema_move_messages\" SET SCHEMA \"moved_messages\"")]
+
+      assert latest =~
+               ~S[execute("ALTER TABLE \"moved_messages\".\"schema_move_messages\" SET SCHEMA \"public\"")]
+
+      refute latest =~ "create table(:schema_move_messages"
+      refute latest =~ "drop table(:schema_move_messages"
+    end
+
+    test "schema move runs before table changes that use the new schema", %{
+      snapshot_path: snapshot_path,
+      migration_path: migration_path
+    } do
+      defresource SchemaMoveColumnMessage, "schema_move_column_messages" do
+        attributes do
+          uuid_primary_key(:id)
+          attribute(:body, :string, public?: true)
+        end
+
+        actions do
+          defaults([:create, :read, :update, :destroy])
+        end
+      end
+
+      defdomain([SchemaMoveColumnMessage])
+
+      AshPostgres.MigrationGenerator.generate(Domain,
+        snapshot_path: snapshot_path,
+        migration_path: migration_path,
+        quiet: true,
+        format: false,
+        auto_name: true,
+        name: "add_schema_move_column_messages"
+      )
+
+      defresource SchemaMoveColumnMessage, "schema_move_column_messages" do
+        postgres do
+          table "schema_move_column_messages"
+          schema "moved_messages_with_column"
+          repo(AshPostgres.TestRepo)
+        end
+
+        attributes do
+          uuid_primary_key(:id)
+          attribute(:body, :string, public?: true)
+          attribute(:subject, :string, public?: true)
+        end
+
+        actions do
+          defaults([:create, :read, :update, :destroy])
+        end
+      end
+
+      defdomain([SchemaMoveColumnMessage])
+
+      AshPostgres.MigrationGenerator.generate(Domain,
+        snapshot_path: snapshot_path,
+        migration_path: migration_path,
+        quiet: true,
+        format: false,
+        auto_name: true,
+        name: "move_messages_schema_and_add_column"
+      )
+
+      migration_files =
+        Path.wildcard("#{migration_path}/**/*.exs")
+        |> Enum.reject(&String.contains?(&1, "extensions"))
+        |> Enum.sort()
+
+      latest =
+        migration_files
+        |> List.last()
+        |> File.read!()
+
+      move_pos =
+        position_of_substring(
+          latest,
+          ~S[execute("ALTER TABLE \"schema_move_column_messages\" SET SCHEMA \"moved_messages_with_column\"")]
+        )
+
+      alter_pos =
+        position_of_substring(
+          latest,
+          ~S[alter table(:schema_move_column_messages, prefix: "moved_messages_with_column") do]
+        )
+
+      assert is_integer(move_pos)
+      assert is_integer(alter_pos)
+      assert move_pos < alter_pos
+      assert latest =~ "add :subject, :text"
+      refute latest =~ "create table(:schema_move_column_messages"
+      refute latest =~ "drop table(:schema_move_column_messages"
+    end
+
+    test "generates alter table set schema when a resource schema changes", %{
+      snapshot_path: snapshot_path,
+      migration_path: migration_path
+    } do
+      defresource SchemaChangeMessage, "schema_change_messages" do
+        postgres do
+          table "schema_change_messages"
+          schema "old_message_schema"
+          repo(AshPostgres.TestRepo)
+        end
+
+        attributes do
+          uuid_primary_key(:id)
+          attribute(:body, :string, public?: true)
+        end
+
+        actions do
+          defaults([:create, :read, :update, :destroy])
+        end
+      end
+
+      defdomain([SchemaChangeMessage])
+
+      AshPostgres.MigrationGenerator.generate(Domain,
+        snapshot_path: snapshot_path,
+        migration_path: migration_path,
+        quiet: true,
+        format: false,
+        auto_name: true,
+        name: "add_schema_change_messages"
+      )
+
+      defresource SchemaChangeMessage, "schema_change_messages" do
+        postgres do
+          table "schema_change_messages"
+          schema "new_message_schema"
+          repo(AshPostgres.TestRepo)
+        end
+
+        attributes do
+          uuid_primary_key(:id)
+          attribute(:body, :string, public?: true)
+        end
+
+        actions do
+          defaults([:create, :read, :update, :destroy])
+        end
+      end
+
+      defdomain([SchemaChangeMessage])
+
+      AshPostgres.MigrationGenerator.generate(Domain,
+        snapshot_path: snapshot_path,
+        migration_path: migration_path,
+        quiet: true,
+        format: false,
+        auto_name: true,
+        name: "change_messages_schema"
+      )
+
+      migration_files =
+        Path.wildcard("#{migration_path}/**/*.exs")
+        |> Enum.reject(&String.contains?(&1, "extensions"))
+        |> Enum.sort()
+
+      latest =
+        migration_files
+        |> List.last()
+        |> File.read!()
+
+      assert latest =~ ~S[execute("CREATE SCHEMA IF NOT EXISTS new_message_schema")]
+
+      assert latest =~
+               ~S[execute("ALTER TABLE \"old_message_schema\".\"schema_change_messages\" SET SCHEMA \"new_message_schema\"")]
+
+      assert latest =~
+               ~S[execute("ALTER TABLE \"new_message_schema\".\"schema_change_messages\" SET SCHEMA \"old_message_schema\"")]
+
+      refute latest =~ "create table(:schema_change_messages"
+      refute latest =~ "drop table(:schema_change_messages"
+    end
+
+    test "moving a referenced table schema does not drop or recreate tables or foreign keys" do
+      defresource ReferencedSchemaMoveAuthorBefore, "referenced_schema_move_authors" do
+        attributes do
+          uuid_primary_key(:id)
+          attribute(:name, :string, public?: true)
+        end
+
+        actions do
+          defaults([:create, :read, :update, :destroy])
+        end
+      end
+
+      defresource ReferencingSchemaMovePostBefore, "referencing_schema_move_posts" do
+        attributes do
+          uuid_primary_key(:id)
+          attribute(:title, :string, public?: true)
+        end
+
+        relationships do
+          belongs_to(:author, ReferencedSchemaMoveAuthorBefore) do
+            public?(true)
+            allow_nil?(false)
+          end
+        end
+
+        actions do
+          defaults([:create, :read, :update, :destroy])
+        end
+      end
+
+      before_resources = [ReferencedSchemaMoveAuthorBefore, ReferencingSchemaMovePostBefore]
+
+      before_snapshots =
+        Enum.flat_map(
+          before_resources,
+          &AshPostgres.MigrationGenerator.get_snapshots(&1, before_resources)
+        )
+
+      defresource ReferencedSchemaMoveAuthorAfter, "referenced_schema_move_authors" do
+        postgres do
+          table "referenced_schema_move_authors"
+          schema "referenced_schema_move"
+          repo(AshPostgres.TestRepo)
+        end
+
+        attributes do
+          uuid_primary_key(:id)
+          attribute(:name, :string, public?: true)
+        end
+
+        actions do
+          defaults([:create, :read, :update, :destroy])
+        end
+      end
+
+      defresource ReferencingSchemaMovePostAfter, "referencing_schema_move_posts" do
+        attributes do
+          uuid_primary_key(:id)
+          attribute(:title, :string, public?: true)
+        end
+
+        relationships do
+          belongs_to(:author, ReferencedSchemaMoveAuthorAfter) do
+            public?(true)
+            allow_nil?(false)
+          end
+        end
+
+        actions do
+          defaults([:create, :read, :update, :destroy])
+        end
+      end
+
+      after_resources = [ReferencedSchemaMoveAuthorAfter, ReferencingSchemaMovePostAfter]
+
+      after_snapshots =
+        Enum.flat_map(
+          after_resources,
+          &AshPostgres.MigrationGenerator.get_snapshots(&1, after_resources)
+        )
+
+      {up, down} =
+        before_snapshots
+        |> AshPostgres.MigrationGenerator.get_operations_from_snapshots(after_snapshots)
+        |> AshPostgres.MigrationGenerator.build_up_and_down()
+
+      assert up =~
+               ~S[execute("ALTER TABLE \"referenced_schema_move_authors\" SET SCHEMA \"referenced_schema_move\"")]
+
+      assert down =~
+               ~S[execute("ALTER TABLE \"referenced_schema_move\".\"referenced_schema_move_authors\" SET SCHEMA \"public\"")]
+
+      refute up =~ "create table(:referenced_schema_move_authors"
+      refute up =~ "drop table(:referenced_schema_move_authors"
+      refute up =~ "create table(:referencing_schema_move_posts"
+      refute up =~ "drop table(:referencing_schema_move_posts"
+      refute up =~ "drop constraint"
+      refute up =~ "references(:referenced_schema_move_authors"
+    end
   end
 end

--- a/test/migration_generator_test.exs
+++ b/test/migration_generator_test.exs
@@ -5382,6 +5382,8 @@ defmodule AshPostgres.MigrationGeneratorTest do
 
       defdomain([SchemaMoveMessage])
 
+      send(self(), {:mix_shell_input, :yes?, true})
+
       AshPostgres.MigrationGenerator.generate(Domain,
         snapshot_path: snapshot_path,
         migration_path: migration_path,
@@ -5458,6 +5460,8 @@ defmodule AshPostgres.MigrationGeneratorTest do
 
       defdomain([SchemaMoveColumnMessage])
 
+      send(self(), {:mix_shell_input, :yes?, true})
+
       AshPostgres.MigrationGenerator.generate(Domain,
         snapshot_path: snapshot_path,
         migration_path: migration_path,
@@ -5526,6 +5530,82 @@ defmodule AshPostgres.MigrationGeneratorTest do
       refute latest =~ "drop table(:schema_move_column_messages"
     end
 
+    test "does not infer a schema move when the prompt is declined", %{
+      snapshot_path: snapshot_path,
+      migration_path: migration_path
+    } do
+      defresource DeclinedSchemaMoveMessage, "declined_schema_move_messages" do
+        attributes do
+          uuid_primary_key(:id)
+          attribute(:body, :string, public?: true)
+        end
+
+        actions do
+          defaults([:create, :read, :update, :destroy])
+        end
+      end
+
+      defdomain([DeclinedSchemaMoveMessage])
+
+      AshPostgres.MigrationGenerator.generate(Domain,
+        snapshot_path: snapshot_path,
+        migration_path: migration_path,
+        quiet: true,
+        format: false,
+        auto_name: true,
+        name: "add_declined_schema_move_messages"
+      )
+
+      defresource DeclinedSchemaMoveMessage, "declined_schema_move_messages" do
+        postgres do
+          table "declined_schema_move_messages"
+          schema "declined_messages"
+          repo(AshPostgres.TestRepo)
+        end
+
+        attributes do
+          uuid_primary_key(:id)
+          attribute(:body, :string, public?: true)
+        end
+
+        actions do
+          defaults([:create, :read, :update, :destroy])
+        end
+      end
+
+      defdomain([DeclinedSchemaMoveMessage])
+
+      send(self(), {:mix_shell_input, :yes?, false})
+      send(self(), {:mix_shell_input, :yes?, false})
+
+      AshPostgres.MigrationGenerator.generate(Domain,
+        snapshot_path: snapshot_path,
+        migration_path: migration_path,
+        quiet: true,
+        format: false,
+        auto_name: true,
+        name: "decline_messages_schema_move"
+      )
+
+      migration_files =
+        Path.wildcard("#{migration_path}/**/*.exs")
+        |> Enum.reject(&String.contains?(&1, "extensions"))
+        |> Enum.sort()
+
+      latest =
+        migration_files
+        |> List.last()
+        |> File.read!()
+
+      assert latest =~
+               ~S[create table(:declined_schema_move_messages, primary_key: false, prefix: "declined_messages") do]
+
+      refute latest =~
+               ~S[execute("ALTER TABLE \"declined_schema_move_messages\" SET SCHEMA \"declined_messages\"")]
+
+      refute latest =~ "drop table(:declined_schema_move_messages)"
+    end
+
     test "generates alter table set schema when a resource schema changes", %{
       snapshot_path: snapshot_path,
       migration_path: migration_path
@@ -5548,6 +5628,8 @@ defmodule AshPostgres.MigrationGeneratorTest do
       end
 
       defdomain([SchemaChangeMessage])
+
+      send(self(), {:mix_shell_input, :yes?, true})
 
       AshPostgres.MigrationGenerator.generate(Domain,
         snapshot_path: snapshot_path,
@@ -5606,6 +5688,89 @@ defmodule AshPostgres.MigrationGeneratorTest do
 
       refute latest =~ "create table(:schema_change_messages"
       refute latest =~ "drop table(:schema_change_messages"
+    end
+
+    test "does not infer an explicit schema-to-schema move when the prompt is declined", %{
+      snapshot_path: snapshot_path,
+      migration_path: migration_path
+    } do
+      defresource DeclinedSchemaChangeMessage, "declined_schema_change_messages" do
+        postgres do
+          table "declined_schema_change_messages"
+          schema "old_declined_message_schema"
+          repo(AshPostgres.TestRepo)
+        end
+
+        attributes do
+          uuid_primary_key(:id)
+          attribute(:body, :string, public?: true)
+        end
+
+        actions do
+          defaults([:create, :read, :update, :destroy])
+        end
+      end
+
+      defdomain([DeclinedSchemaChangeMessage])
+
+      AshPostgres.MigrationGenerator.generate(Domain,
+        snapshot_path: snapshot_path,
+        migration_path: migration_path,
+        quiet: true,
+        format: false,
+        auto_name: true,
+        name: "add_declined_schema_change_messages"
+      )
+
+      defresource DeclinedSchemaChangeMessage, "declined_schema_change_messages" do
+        postgres do
+          table "declined_schema_change_messages"
+          schema "new_declined_message_schema"
+          repo(AshPostgres.TestRepo)
+        end
+
+        attributes do
+          uuid_primary_key(:id)
+          attribute(:body, :string, public?: true)
+        end
+
+        actions do
+          defaults([:create, :read, :update, :destroy])
+        end
+      end
+
+      defdomain([DeclinedSchemaChangeMessage])
+
+      send(self(), {:mix_shell_input, :yes?, false})
+      send(self(), {:mix_shell_input, :yes?, false})
+
+      AshPostgres.MigrationGenerator.generate(Domain,
+        snapshot_path: snapshot_path,
+        migration_path: migration_path,
+        quiet: true,
+        format: false,
+        auto_name: true,
+        name: "decline_messages_schema_change"
+      )
+
+      migration_files =
+        Path.wildcard("#{migration_path}/**/*.exs")
+        |> Enum.reject(&String.contains?(&1, "extensions"))
+        |> Enum.sort()
+
+      latest =
+        migration_files
+        |> List.last()
+        |> File.read!()
+
+      assert latest =~
+               ~S[create table(:declined_schema_change_messages, primary_key: false, prefix: "new_declined_message_schema") do]
+
+      refute latest =~
+               ~S[execute("ALTER TABLE \"old_declined_message_schema\".\"declined_schema_change_messages\" SET SCHEMA \"new_declined_message_schema\"")]
+
+      refute latest =~
+               ~S[drop table(:declined_schema_change_messages, prefix: "old_declined_message_schema")]
     end
 
     test "moving a referenced table schema does not drop or recreate tables or foreign keys" do


### PR DESCRIPTION
# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

**Summary**

Resolves issue https://github.com/ash-project/ash_postgres/issues/731
Fixes schema-only resource changes being generated as `drop table` + `create table`.

The generator matches snapshots by `{table, schema}`, so changing only `schema "..."` made the old table look removed and the new schema table look newly added. This PR detects same-table/different-schema changes as schema moves and emits `ALTER TABLE ... SET SCHEMA ...` instead, preserving existing data.

**Changes**

- Added `MoveTableSchema` operation.
- Reconnects old/new snapshots when a table moves schemas.
- Prevents orphaned old-schema snapshots from becoming table drops.
- Ensures schema moves run before later changes against the new schema.
- Avoids unnecessary FK drop/recreate when a referenced table moved schemas.
- Tests

**Added test coverage for:**

- Adding a schema to an existing table.
- Moving from one schema to another.
- Moving schema and adding a column in the same migration.
- Moving a referenced table without recreating FKs.
