### PR TITLE
bug: Demonstrate `AshPostgres.Timestamptz` operator overloading causing precision loss in keyset pagination

### DIFF
--- a/test/sort_test.exs
+++ b/test/sort_test.exs
@@ -446,4 +446,42 @@ defmodule AshPostgres.SortTest do
       |> Ash.read!()
     end
   end
+
+  describe "keyset pagination on microsecond-precision datetime columns" do
+    test "next page returns the remaining rows when sorting by created_at desc" do
+      # All three posts share the same second; only microseconds differ —
+      # exposes precision loss between the eq and lt sides of the keyset filter.
+      base = ~U[2026-05-25 05:34:24Z]
+
+      [post1, post2, post3] =
+        Enum.map([10_000, 20_000, 30_000], fn usec ->
+          Post
+          |> Ash.Changeset.for_create(:create, %{
+            title: "post-#{usec}",
+            created_at: %{base | microsecond: {usec, 6}}
+          })
+          |> Ash.create!()
+        end)
+
+      %{results: [first, cursor_row]} =
+        Post
+        |> Ash.Query.for_read(:keyset)
+        |> Ash.Query.sort(created_at: :desc)
+        |> Ash.Query.page(limit: 2)
+        |> Ash.read!()
+
+      assert first.id == post3.id
+      assert cursor_row.id == post2.id
+
+      %{results: results} =
+        Post
+        |> Ash.Query.for_read(:keyset)
+        |> Ash.Query.sort(created_at: :desc)
+        |> Ash.Query.page(limit: 2, after: cursor_row.__metadata__.keyset)
+        |> Ash.read!()
+
+      assert length(results) == 1
+      assert hd(results).id == post1.id
+    end
+  end
 end


### PR DESCRIPTION
Discovered while investigating https://github.com/sevenseacat/cinder/issues/176 and tracing it back to a problem upstream.

The failing test demonstrates the problem - sorting by the timestamp causes issues when navigating between pages, as precision is lost in the timestamp comparison. 

The root cause appears to be `ash_postgres/lib/types/timestamptz.ex:44-79` - `operator_overloads/0` overloads only `<`, `<=`, `>`, `>=`, and the match check via `Ash.Expr.determine_types` uses `matches_type?`, which is permissive enough that any `%DateTime{}` value matches the `Timestamptz` slot. So users with plain `UtcDatetimeUsec` columns get their ordering comparisons silently force-cast to seconds-precision `Timestamptz`, while their equality comparisons keep microsecond precision.

Demo:

```iex
iex(1)> resource = CinderSort.Locations.Location
CinderSort.Locations.Location

iex(2)> attr = Ash.Resource.Info.field(resource, :inserted_at)
%Ash.Resource.Attribute{
  name: :inserted_at,
  type: Ash.Type.UtcDatetimeUsec,
  ...
  }
}

iex(3)> Ash.Type.storage_type(attr.type, attr.constraints)
:utc_datetime_usec

iex(4)> ref = %Ash.Query.Ref{attribute: attr, relationship_path: [], resource: resource}
inserted_at

iex(5)> value = ~U[2026-05-25 05:34:24.130812Z]
~U[2026-05-25 05:34:24.130812Z]

iex(6)> Ash.Expr.determine_types(Ash.Query.Operator.Eq, [ref, value])
{[
   {Ash.Type.UtcDatetimeUsec,
    [precision: :microsecond, cast_dates_as: :start_of_day, timezone: :utc]},
   {Ash.Type.UtcDatetimeUsec,
    [precision: :microsecond, cast_dates_as: :start_of_day, timezone: :utc]}
 ], {Ash.Type.Boolean, []}}

iex(7)> Ash.Expr.determine_types(Ash.Query.Operator.LessThan, [ref, value])
{[{AshPostgres.Timestamptz, []}, {AshPostgres.Timestamptz, []}],
 {Ash.Type.Boolean, []}}

iex(8)> Ash.Expr.determine_types(Ash.Query.Operator.GreaterThan, [ref, value])
{[{AshPostgres.Timestamptz, []}, {AshPostgres.Timestamptz, []}],
 {Ash.Type.Boolean, []}}
```

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
