### PR TITLE
fix: rewrite belongs_to reference indexes when multitenancy changes

### DIFF
--- a/lib/migration_generator/migration_generator.ex
+++ b/lib/migration_generator/migration_generator.ex
@@ -2443,8 +2443,11 @@ defmodule AshPostgres.MigrationGenerator do
             attribute.references && attribute.references[:index?]
 
           old_attribute ->
-            (old_attribute.references && old_attribute.references[:index?]) !=
-              (attribute.references && attribute.references[:index?])
+            new_index? = attribute.references && attribute.references[:index?]
+            old_index? = old_attribute.references && old_attribute.references[:index?]
+
+            old_index? != new_index? ||
+              (new_index? && multitenancy_changed?)
         end
       end)
       |> Enum.map(fn attribute ->
@@ -2468,7 +2471,11 @@ defmodule AshPostgres.MigrationGenerator do
 
         attribute_doesnt_exist? = !attribute && old_attribute[:references][:index?]
 
-        has_removed_index? || attribute_doesnt_exist?
+        multitenancy_change_requires_rewrite? =
+          attribute && old_attribute[:references][:index?] && attribute[:references][:index?] &&
+            multitenancy_changed?
+
+        has_removed_index? || attribute_doesnt_exist? || multitenancy_change_requires_rewrite?
       end)
       |> Enum.map(fn attribute ->
         %Operation.RemoveReferenceIndex{

--- a/test/migration_generator_test.exs
+++ b/test/migration_generator_test.exs
@@ -2662,6 +2662,202 @@ defmodule AshPostgres.MigrationGeneratorTest do
       assert down_code =~ ~S{drop_if_exists index(:posts, [:org_id])}
     end
 
+    test "transitioning from non-multitenant to attribute multitenancy drops single-column belongs_to indexes and creates composite ones",
+         %{
+           snapshot_path: snapshot_path,
+           migration_path: migration_path
+         } do
+      defresource OrgForMtTransition, "orgs_for_mt_transition" do
+        attributes do
+          uuid_primary_key(:id, writable?: true, public?: true)
+          attribute(:name, :string, public?: true)
+        end
+
+        multitenancy do
+          strategy(:attribute)
+          attribute(:id)
+        end
+      end
+
+      defresource UserForMtTransition, "users_for_mt_transition" do
+        attributes do
+          uuid_primary_key(:id, writable?: true, public?: true)
+          attribute(:name, :string, public?: true)
+        end
+      end
+
+      defresource TokenForMtTransition, "tokens_for_mt_transition" do
+        attributes do
+          uuid_primary_key(:id)
+          attribute(:name, :string, public?: true)
+        end
+
+        relationships do
+          belongs_to(:user, UserForMtTransition, public?: true)
+        end
+
+        postgres do
+          references do
+            reference(:user, index?: true)
+          end
+        end
+      end
+
+      defdomain([OrgForMtTransition, UserForMtTransition, TokenForMtTransition])
+
+      AshPostgres.MigrationGenerator.generate(Domain,
+        snapshot_path: snapshot_path,
+        migration_path: migration_path,
+        quiet: true,
+        format: false,
+        auto_name: true
+      )
+
+      defresource TokenForMtTransition, "tokens_for_mt_transition" do
+        attributes do
+          uuid_primary_key(:id)
+          attribute(:name, :string, public?: true)
+        end
+
+        multitenancy do
+          strategy(:attribute)
+          attribute(:org_id)
+        end
+
+        relationships do
+          belongs_to(:org, OrgForMtTransition, public?: true)
+          belongs_to(:user, UserForMtTransition, public?: true)
+        end
+
+        postgres do
+          references do
+            reference(:user, index?: true)
+          end
+        end
+      end
+
+      defdomain([OrgForMtTransition, UserForMtTransition, TokenForMtTransition])
+
+      AshPostgres.MigrationGenerator.generate(Domain,
+        snapshot_path: snapshot_path,
+        migration_path: migration_path,
+        quiet: true,
+        format: false,
+        auto_name: true
+      )
+
+      [_first, second] =
+        Path.wildcard("#{migration_path}/**/*_migrate_resources*.exs")
+        |> Enum.reject(&String.contains?(&1, "extensions"))
+        |> Enum.sort()
+
+      content = File.read!(second)
+
+      assert content =~ ~S{drop_if_exists index(:tokens_for_mt_transition, [:user_id])},
+             "should drop the obsolete single-column belongs_to index when acquiring multitenancy"
+
+      assert content =~ ~S{create index(:tokens_for_mt_transition, [:org_id, :user_id])},
+             "should create the new composite belongs_to index when acquiring multitenancy"
+    end
+
+    test "transitioning from attribute multitenancy to non-multitenant drops composite belongs_to indexes and creates single-column ones",
+         %{
+           snapshot_path: snapshot_path,
+           migration_path: migration_path
+         } do
+      defresource OrgForMtDrop, "orgs_for_mt_drop" do
+        attributes do
+          uuid_primary_key(:id, writable?: true, public?: true)
+          attribute(:name, :string, public?: true)
+        end
+
+        multitenancy do
+          strategy(:attribute)
+          attribute(:id)
+        end
+      end
+
+      defresource UserForMtDrop, "users_for_mt_drop" do
+        attributes do
+          uuid_primary_key(:id, writable?: true, public?: true)
+          attribute(:name, :string, public?: true)
+        end
+      end
+
+      defresource TokenForMtDrop, "tokens_for_mt_drop" do
+        attributes do
+          uuid_primary_key(:id)
+          attribute(:name, :string, public?: true)
+        end
+
+        multitenancy do
+          strategy(:attribute)
+          attribute(:org_id)
+        end
+
+        relationships do
+          belongs_to(:org, OrgForMtDrop, public?: true)
+          belongs_to(:user, UserForMtDrop, public?: true)
+        end
+
+        postgres do
+          references do
+            reference(:user, index?: true)
+          end
+        end
+      end
+
+      defdomain([OrgForMtDrop, UserForMtDrop, TokenForMtDrop])
+
+      AshPostgres.MigrationGenerator.generate(Domain,
+        snapshot_path: snapshot_path,
+        migration_path: migration_path,
+        quiet: true,
+        format: false,
+        auto_name: true
+      )
+
+      defresource TokenForMtDrop, "tokens_for_mt_drop" do
+        attributes do
+          uuid_primary_key(:id)
+          attribute(:name, :string, public?: true)
+        end
+
+        relationships do
+          belongs_to(:user, UserForMtDrop, public?: true)
+        end
+
+        postgres do
+          references do
+            reference(:user, index?: true)
+          end
+        end
+      end
+
+      defdomain([OrgForMtDrop, UserForMtDrop, TokenForMtDrop])
+
+      AshPostgres.MigrationGenerator.generate(Domain,
+        snapshot_path: snapshot_path,
+        migration_path: migration_path,
+        quiet: true,
+        format: false,
+        auto_name: true
+      )
+
+      [_first, second] =
+        Path.wildcard("#{migration_path}/**/*_migrate_resources*.exs")
+        |> Enum.reject(&String.contains?(&1, "extensions"))
+        |> Enum.sort()
+
+      content = File.read!(second)
+
+      assert content =~ ~S{drop_if_exists index(:tokens_for_mt_drop, [:org_id, :user_id])},
+             "should drop the obsolete composite belongs_to index when removing multitenancy"
+
+      assert content =~ ~S{create index(:tokens_for_mt_drop, [:user_id])},
+             "should create the new single-column belongs_to index when removing multitenancy"
+    end
+
     test "references merge :match_with and multitenancy attribute", %{
       snapshot_path: snapshot_path,
       migration_path: migration_path


### PR DESCRIPTION
# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

## Summary

When a resource transitions between non-multitenant and attribute multitenancy, `references` with `index?: true` on `belongs_to` should switch between single-column `(fk)` and composite `(tenant, fk)` indexes. The reference-index diff only compared the `index?` boolean, so when the multitenancy block changed but `index?` stayed the same, no operation was emitted — leaving the wrong index shape in the database.

Custom indexes and identities already handle this via `rewrite_for_multitenancy_change?`; reference indexes were missing the same check.

## Fix

Extend `reference_indexes_to_add` / `reference_indexes_to_remove` to also trigger when `multitenancy_changed?` is true and the reference still has `index?: true`. The existing `Add/RemoveReferenceIndex` operations already resolve the correct column tuple from `multitenancy` / `old_multitenancy`, so no snapshot format changes are needed.

Generated migration when adding multitenancy now includes:

```elixir
drop_if_exists index(:tokens, [:user_id])
create index(:tokens, [:org_id, :user_id])
```