### PR TITLE
chore: finalize test_repo dev migration

### DIFF
--- a/priv/resource_snapshots/test_repo/classrooms/20260526092628.json
+++ b/priv/resource_snapshots/test_repo/classrooms/20260526092628.json
@@ -1,0 +1,87 @@
+{
+  "attributes": [
+    {
+      "allow_nil?": false,
+      "default": "fragment(\"gen_random_uuid()\")",
+      "generated?": false,
+      "precision": null,
+      "primary_key?": true,
+      "references": null,
+      "scale": null,
+      "size": null,
+      "source": "id",
+      "type": "uuid"
+    },
+    {
+      "allow_nil?": true,
+      "default": "nil",
+      "generated?": false,
+      "precision": null,
+      "primary_key?": false,
+      "references": null,
+      "scale": null,
+      "size": null,
+      "source": "name",
+      "type": "text"
+    },
+    {
+      "allow_nil?": true,
+      "default": "true",
+      "generated?": false,
+      "precision": null,
+      "primary_key?": false,
+      "references": null,
+      "scale": null,
+      "size": null,
+      "source": "public",
+      "type": "boolean"
+    },
+    {
+      "allow_nil?": true,
+      "default": "nil",
+      "generated?": false,
+      "precision": null,
+      "primary_key?": false,
+      "references": {
+        "deferrable": false,
+        "destination_attribute": "id",
+        "destination_attribute_default": null,
+        "destination_attribute_generated": null,
+        "index?": false,
+        "match_type": null,
+        "match_with": null,
+        "multitenancy": {
+          "attribute": null,
+          "global": null,
+          "strategy": null
+        },
+        "name": "classrooms_school_id_fkey",
+        "on_delete": null,
+        "on_update": null,
+        "primary_key?": true,
+        "schema": "public",
+        "table": "schools"
+      },
+      "scale": null,
+      "size": null,
+      "source": "school_id",
+      "type": "uuid"
+    }
+  ],
+  "base_filter": null,
+  "check_constraints": [],
+  "create_table_options": null,
+  "custom_indexes": [],
+  "custom_statements": [],
+  "has_create_action": true,
+  "hash": "4684AC6188DE38903A97279A2665A3915910B0C9BD314DEBDEB50E43747F2CC6",
+  "identities": [],
+  "multitenancy": {
+    "attribute": null,
+    "global": null,
+    "strategy": null
+  },
+  "repo": "Elixir.AshPostgres.TestRepo",
+  "schema": null,
+  "table": "classrooms"
+}

--- a/priv/resource_snapshots/test_repo/interest.interests/20260526092630.json
+++ b/priv/resource_snapshots/test_repo/interest.interests/20260526092630.json
@@ -13,7 +13,7 @@
       "type": "uuid"
     },
     {
-      "allow_nil?": false,
+      "allow_nil?": true,
       "default": "nil",
       "generated?": false,
       "precision": null,
@@ -21,7 +21,7 @@
       "references": null,
       "scale": null,
       "size": null,
-      "source": "value",
+      "source": "name",
       "type": "text"
     }
   ],
@@ -31,29 +31,14 @@
   "custom_indexes": [],
   "custom_statements": [],
   "has_create_action": true,
-  "hash": "094DD4BC4D82A17CF6976D4787FFAE874FCF2F7286AD4411441A7D547CBFC1CB",
-  "identities": [
-    {
-      "all_tenants?": false,
-      "base_filter": null,
-      "index_name": "labels_unique_value_index",
-      "keys": [
-        {
-          "type": "atom",
-          "value": "value"
-        }
-      ],
-      "name": "unique_value",
-      "nils_distinct?": true,
-      "where": null
-    }
-  ],
+  "hash": "F67A136F4A1A7E6C289CE6D3E912E3B1A97041DCC8453DD49AA471D84248753E",
+  "identities": [],
   "multitenancy": {
     "attribute": null,
     "global": null,
     "strategy": null
   },
   "repo": "Elixir.AshPostgres.TestRepo",
-  "schema": null,
-  "table": "labels"
+  "schema": "interest",
+  "table": "interests"
 }

--- a/priv/resource_snapshots/test_repo/labels/20260515075841_dev.json.license
+++ b/priv/resource_snapshots/test_repo/labels/20260515075841_dev.json.license
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2019 ash_postgres contributors <https://github.com/ash-project/ash_postgres/graphs/contributors>
-
-SPDX-License-Identifier: MIT

--- a/priv/resource_snapshots/test_repo/labels/20260526092626.json
+++ b/priv/resource_snapshots/test_repo/labels/20260526092626.json
@@ -1,0 +1,59 @@
+{
+  "attributes": [
+    {
+      "allow_nil?": false,
+      "default": "fragment(\"gen_random_uuid()\")",
+      "generated?": false,
+      "precision": null,
+      "primary_key?": true,
+      "references": null,
+      "scale": null,
+      "size": null,
+      "source": "id",
+      "type": "uuid"
+    },
+    {
+      "allow_nil?": false,
+      "default": "nil",
+      "generated?": false,
+      "precision": null,
+      "primary_key?": false,
+      "references": null,
+      "scale": null,
+      "size": null,
+      "source": "value",
+      "type": "text"
+    }
+  ],
+  "base_filter": null,
+  "check_constraints": [],
+  "create_table_options": null,
+  "custom_indexes": [],
+  "custom_statements": [],
+  "has_create_action": true,
+  "hash": "E368893F6C9F4429F9464443FAB91D04D425365CF05498A09AE2F09E91883C78",
+  "identities": [
+    {
+      "all_tenants?": false,
+      "base_filter": null,
+      "index_name": "labels_unique_value_index",
+      "keys": [
+        {
+          "type": "atom",
+          "value": "value"
+        }
+      ],
+      "name": "unique_value",
+      "nils_distinct?": true,
+      "where": null
+    }
+  ],
+  "multitenancy": {
+    "attribute": null,
+    "global": null,
+    "strategy": null
+  },
+  "repo": "Elixir.AshPostgres.TestRepo",
+  "schema": null,
+  "table": "labels"
+}

--- a/priv/resource_snapshots/test_repo/post_labels/20260515075842_dev.json.license
+++ b/priv/resource_snapshots/test_repo/post_labels/20260515075842_dev.json.license
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2019 ash_postgres contributors <https://github.com/ash-project/ash_postgres/graphs/contributors>
-
-SPDX-License-Identifier: MIT

--- a/priv/resource_snapshots/test_repo/post_labels/20260526092627.json
+++ b/priv/resource_snapshots/test_repo/post_labels/20260526092627.json
@@ -41,7 +41,7 @@
       "scale": null,
       "size": null,
       "source": "content_id",
-      "type": "bigint"
+      "type": "uuid"
     },
     {
       "allow_nil?": false,
@@ -126,7 +126,7 @@
   ],
   "custom_statements": [],
   "has_create_action": true,
-  "hash": "6DBB60B6D32729CEAE9266383990DC834AA776EB5E87F620B595ADA0326C00B5",
+  "hash": "93DA33C9435A810642A1C08B6430C24BAA7497D5ED8F60E24A877BFFD487DD9A",
   "identities": [
     {
       "all_tenants?": false,

--- a/priv/resource_snapshots/test_repo/profiles.profile_interests/20260526092629.json
+++ b/priv/resource_snapshots/test_repo/profiles.profile_interests/20260526092629.json
@@ -1,0 +1,113 @@
+{
+  "attributes": [
+    {
+      "allow_nil?": false,
+      "default": "fragment(\"gen_random_uuid()\")",
+      "generated?": false,
+      "precision": null,
+      "primary_key?": true,
+      "references": null,
+      "scale": null,
+      "size": null,
+      "source": "id",
+      "type": "uuid"
+    },
+    {
+      "allow_nil?": false,
+      "default": "nil",
+      "generated?": false,
+      "precision": null,
+      "primary_key?": false,
+      "references": {
+        "deferrable": false,
+        "destination_attribute": "id",
+        "destination_attribute_default": null,
+        "destination_attribute_generated": null,
+        "index?": false,
+        "match_type": null,
+        "match_with": null,
+        "multitenancy": {
+          "attribute": null,
+          "global": null,
+          "strategy": null
+        },
+        "name": "profile_interests_profile_id_fkey",
+        "on_delete": null,
+        "on_update": null,
+        "primary_key?": true,
+        "schema": "profiles",
+        "table": "profile"
+      },
+      "scale": null,
+      "size": null,
+      "source": "profile_id",
+      "type": "uuid"
+    },
+    {
+      "allow_nil?": false,
+      "default": "nil",
+      "generated?": false,
+      "precision": null,
+      "primary_key?": false,
+      "references": {
+        "deferrable": false,
+        "destination_attribute": "id",
+        "destination_attribute_default": null,
+        "destination_attribute_generated": null,
+        "index?": false,
+        "match_type": null,
+        "match_with": null,
+        "multitenancy": {
+          "attribute": null,
+          "global": null,
+          "strategy": null
+        },
+        "name": "profile_interests_interest_id_fkey",
+        "on_delete": null,
+        "on_update": null,
+        "primary_key?": true,
+        "schema": "interest",
+        "table": "interests"
+      },
+      "scale": null,
+      "size": null,
+      "source": "interest_id",
+      "type": "uuid"
+    }
+  ],
+  "base_filter": null,
+  "check_constraints": [],
+  "create_table_options": null,
+  "custom_indexes": [],
+  "custom_statements": [],
+  "has_create_action": true,
+  "hash": "ED2566F3CC2AF7C6FE80477A33344F1B260ECA4AD0E181071A123C4CA32589CE",
+  "identities": [
+    {
+      "all_tenants?": false,
+      "base_filter": null,
+      "index_name": "profile_interests_unique_profile_interest_index",
+      "keys": [
+        {
+          "type": "atom",
+          "value": "profile_id"
+        },
+        {
+          "type": "atom",
+          "value": "interest_id"
+        }
+      ],
+      "name": "unique_profile_interest",
+      "nils_distinct?": true,
+      "where": null
+    }
+  ],
+  "multitenancy": {
+    "attribute": null,
+    "global": null,
+    "strategy": null
+  },
+  "repo": "Elixir.AshPostgres.TestRepo",
+  "schema": "profiles",
+  "table": "profile_interests"
+}

--- a/priv/test_repo/migrations/20260526092625_migrate_resource71.exs
+++ b/priv/test_repo/migrations/20260526092625_migrate_resource71.exs
@@ -1,8 +1,4 @@
-# SPDX-FileCopyrightText: 2019 ash_postgres contributors <https://github.com/ash-project/ash_postgres/graphs/contributors>
-#
-# SPDX-License-Identifier: MIT
-
-defmodule AshPostgres.TestRepo.Migrations.MigrateResources71 do
+defmodule AshPostgres.TestRepo.Migrations.MigrateResource71 do
   @moduledoc """
   Updates resources based on their most recent snapshots.
 
@@ -12,6 +8,52 @@ defmodule AshPostgres.TestRepo.Migrations.MigrateResources71 do
   use Ecto.Migration
 
   def up do
+    execute("CREATE SCHEMA IF NOT EXISTS interest")
+
+    create table(:interests, primary_key: false, prefix: "interest") do
+      add(:id, :uuid, null: false, default: fragment("gen_random_uuid()"), primary_key: true)
+      add(:name, :text)
+    end
+
+    execute("CREATE SCHEMA IF NOT EXISTS profiles")
+
+    create table(:profile_interests, primary_key: false, prefix: "profiles") do
+      add(:id, :uuid, null: false, default: fragment("gen_random_uuid()"), primary_key: true)
+
+      add(
+        :profile_id,
+        references(:profile,
+          column: :id,
+          name: "profile_interests_profile_id_fkey",
+          type: :uuid,
+          prefix: "profiles"
+        ),
+        null: false
+      )
+
+      add(
+        :interest_id,
+        references(:interests,
+          column: :id,
+          name: "profile_interests_interest_id_fkey",
+          type: :uuid,
+          prefix: "interest"
+        ),
+        null: false
+      )
+    end
+
+    create(
+      unique_index(:profile_interests, [:profile_id, :interest_id],
+        name: "profile_interests_unique_profile_interest_index",
+        prefix: "profiles"
+      )
+    )
+
+    alter table(:classrooms) do
+      add(:public, :boolean, default: true)
+    end
+
     create table(:post_labels, primary_key: false) do
       add(:id, :uuid, null: false, default: fragment("gen_random_uuid()"), primary_key: true)
 
@@ -86,5 +128,24 @@ defmodule AshPostgres.TestRepo.Migrations.MigrateResources71 do
     drop_if_exists(index(:post_labels, [:label_id]))
 
     drop(table(:post_labels))
+
+    alter table(:classrooms) do
+      remove(:public)
+    end
+
+    drop(constraint(:profile_interests, "profile_interests_profile_id_fkey", prefix: "profiles"))
+
+    drop(constraint(:profile_interests, "profile_interests_interest_id_fkey", prefix: "profiles"))
+
+    drop_if_exists(
+      unique_index(:profile_interests, [:profile_id, :interest_id],
+        name: "profile_interests_unique_profile_interest_index",
+        prefix: "profiles"
+      )
+    )
+
+    drop(table(:profile_interests, prefix: "profiles"))
+
+    drop(table(:interests, prefix: "interest"))
   end
 end


### PR DESCRIPTION
# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [x] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

The dev-mode migration in `priv/test_repo/migrations/` was committed without being squashed, so test_repo snapshots showed up untracked on every codegen run. Ran `mix ash_postgres.generate_migrations` to replace the dev migration with a finalized one and commit the matching snapshots.