### PR TITLE
chore: drop duplicate statements from migrate_resource71

### DIFF
--- a/priv/test_repo/migrations/20260526092625_migrate_resource71.exs
+++ b/priv/test_repo/migrations/20260526092625_migrate_resource71.exs
@@ -8,52 +8,6 @@ defmodule AshPostgres.TestRepo.Migrations.MigrateResource71 do
   use Ecto.Migration
 
   def up do
-    execute("CREATE SCHEMA IF NOT EXISTS interest")
-
-    create table(:interests, primary_key: false, prefix: "interest") do
-      add(:id, :uuid, null: false, default: fragment("gen_random_uuid()"), primary_key: true)
-      add(:name, :text)
-    end
-
-    execute("CREATE SCHEMA IF NOT EXISTS profiles")
-
-    create table(:profile_interests, primary_key: false, prefix: "profiles") do
-      add(:id, :uuid, null: false, default: fragment("gen_random_uuid()"), primary_key: true)
-
-      add(
-        :profile_id,
-        references(:profile,
-          column: :id,
-          name: "profile_interests_profile_id_fkey",
-          type: :uuid,
-          prefix: "profiles"
-        ),
-        null: false
-      )
-
-      add(
-        :interest_id,
-        references(:interests,
-          column: :id,
-          name: "profile_interests_interest_id_fkey",
-          type: :uuid,
-          prefix: "interest"
-        ),
-        null: false
-      )
-    end
-
-    create(
-      unique_index(:profile_interests, [:profile_id, :interest_id],
-        name: "profile_interests_unique_profile_interest_index",
-        prefix: "profiles"
-      )
-    )
-
-    alter table(:classrooms) do
-      add(:public, :boolean, default: true)
-    end
-
     create table(:post_labels, primary_key: false) do
       add(:id, :uuid, null: false, default: fragment("gen_random_uuid()"), primary_key: true)
 
@@ -128,24 +82,5 @@ defmodule AshPostgres.TestRepo.Migrations.MigrateResource71 do
     drop_if_exists(index(:post_labels, [:label_id]))
 
     drop(table(:post_labels))
-
-    alter table(:classrooms) do
-      remove(:public)
-    end
-
-    drop(constraint(:profile_interests, "profile_interests_profile_id_fkey", prefix: "profiles"))
-
-    drop(constraint(:profile_interests, "profile_interests_interest_id_fkey", prefix: "profiles"))
-
-    drop_if_exists(
-      unique_index(:profile_interests, [:profile_id, :interest_id],
-        name: "profile_interests_unique_profile_interest_index",
-        prefix: "profiles"
-      )
-    )
-
-    drop(table(:profile_interests, prefix: "profiles"))
-
-    drop(table(:interests, prefix: "interest"))
   end
 end


### PR DESCRIPTION
# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [x] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

Follow-up to #763. I only checked the codegen output when finalizing the dev migration and didn't run `mix test.reset` until afterwards — sorry about that.

## Problem

`mix test.reset` fails on main with `duplicate_table` because `20260526092625_migrate_resource71.exs` re-creates tables/columns that earlier hand-written migrations already produced:

| Duplicated | Original migration |
| --- | --- |
| `interest.interests` | `20260414095619_add_cross_schema_many_to_many_test.exs` |
| `profiles.profile_interests` + unique index | same as above |
| `classrooms.public` | `20260206120932_add_public_to_classrooms.exs` |

Those hand-written migrations were committed without matching resource snapshots, so when the dev migration was finalized via `mix ash_postgres.generate_migrations`, the codegen diff treated those tables/columns as new and emitted `create table` / `add column` statements again.

## Fix

Strip the overlapping blocks from both `up` and `down` in `20260526092625_migrate_resource71.exs` so the migration only applies the genuinely new changes (`post_labels`, `labels`). Snapshots stay as-is — they correctly represent the current schema and serve as the baseline going forward.

