### PR TITLE
fix: cond/if calculation in query filters causes DBConnection.EncodeError

### DIFF
--- a/test/calculation_test.exs
+++ b/test/calculation_test.exs
@@ -1100,6 +1100,31 @@ defmodule AshPostgres.CalculationTest do
     assert full_name == "name"
   end
 
+  test "cond/if calculation can be used in query filters" do
+    post =
+      Post
+      |> Ash.Changeset.for_create(:create, %{title: "match", score: 75})
+      |> Ash.create!()
+
+    # Loading the cond-based calculation works fine
+    post = Ash.load!(post, :score_category)
+    assert post.score_category == 2
+
+    # Filtering by a cond-based calculation should also work.
+    # This currently fails with DBConnection.EncodeError because the THEN
+    # clause literals in the generated CASE WHEN are not type-cast when the
+    # expression appears in a WHERE clause (they ARE cast in SELECT).
+    assert [_] =
+             Post
+             |> Ash.Query.filter(score_category == 2)
+             |> Ash.read!()
+
+    assert [] =
+             Post
+             |> Ash.Query.filter(score_category == 3)
+             |> Ash.read!()
+  end
+
   test "calculation with fragment and cond returning integer doesn't cause Postgrex encoding error" do
     Post
     |> Ash.Changeset.for_create(:create, %{title: "hello ash lovers"})

--- a/test/support/resources/post.ex
+++ b/test/support/resources/post.ex
@@ -1124,6 +1124,20 @@ defmodule AshPostgres.Test.Post do
 
     calculate(:c_times_p, :integer, expr(count_of_comments * count_of_linked_posts))
 
+
+    calculate(
+      :score_category,
+      :integer,
+      expr(
+        cond do
+          score > 100 -> 3
+          score > 50 -> 2
+          score > 0 -> 1
+          true -> 0
+        end
+      )
+    )
+
     calculate(
       :literal_map_in_expr,
       :map,


### PR DESCRIPTION
## Summary

Using a `cond` or `if` expression calculation in a query **filter** causes a `DBConnection.EncodeError` because the THEN/ELSE clause literals in the generated SQL `CASE WHEN` are not type-cast in the WHERE context, while they are properly cast in SELECT.

## Reproduction

The PR adds a failing test that demonstrates the issue. A `score_category` calculation using `cond` is added to the `Post` test resource:

```elixir
calculate(:score_category, :integer,
  expr(
    cond do
      score > 100 -> 3
      score > 50 -> 2
      score > 0 -> 1
      true -> 0
    end
  )
)
```

**Loading** the calculation works fine — the SQL correctly casts THEN values:
```sql
SELECT ... (CASE WHEN (score > 100) THEN 3::bigint ... END)::bigint ...
```

**Filtering** on the same calculation fails:
```sql
WHERE (CASE WHEN (score > 100) THEN 3 ... END)::bigint = 2
-- DBConnection.EncodeError: Postgrex expected a binary, got 3
```

The missing `::bigint` casts on the THEN literals cause Postgrex to fail parameter encoding.

## Root cause

The bug is in `ash_sql` (`deps/ash_sql/lib/expr.ex`).

When Ash converts `cond` to nested `If` nodes, the `%If{}` struct has `embedded?: true`. The `If` handler in `default_dynamic_expr/6` calls `do_dynamic_expr` for each THEN/ELSE value, passing the resolved type (e.g. `:integer`). However, because `embedded?` is `true`, the call dispatches to the `default_dynamic_expr(query, other, bindings, true, acc, type)` clause (line ~2990), which calls `handle_literal` but **does not apply type casting** — unlike the `embedded? = false` clause (line ~3037) which does call `parameterized_type` + `type_expr`.

This means the THEN value `3` is passed as a raw integer into the Fragment's `:casted_expr` parameter with type `:any`. Postgrex cannot infer the correct encoding from the CASE context and defaults to `text`, producing the binary-vs-integer mismatch.

## Impact

Any `cond`/`if` expression calculation (returning integers, floats, etc.) that is used in an `Ash.Query.filter` will fail. This also affects Ash policy `FilterCheck` modules that reference such calculations, breaking authorization on bulk operations.