### PR TITLE
chore: update to Elixir 1.20 and clean build suite

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
 erlang 27.1.2
-elixir 1.18.1
+elixir 1.20
 pipx 1.8.0

--- a/lib/data_layer.ex
+++ b/lib/data_layer.ex
@@ -1693,8 +1693,12 @@ defmodule AshPostgres.DataLayer do
     Ash.Query.do_filter(query, expr)
   end
 
-  defp get_subquery(%Ecto.Query{} = query), do: query
-  defp get_subquery(%Ecto.SubQuery{query: query}), do: query
+  defp get_subquery(query) do
+    case query do
+      %Ecto.SubQuery{query: query} -> query
+      %Ecto.Query{} -> query
+    end
+  end
 
   @doc false
   def set_subquery_prefix(data_layer_query, source_query, resource) do

--- a/lib/mix/tasks/ash_postgres.install.ex
+++ b/lib/mix/tasks/ash_postgres.install.ex
@@ -6,7 +6,6 @@ if Code.ensure_loaded?(Igniter) do
   defmodule Mix.Tasks.AshPostgres.Install do
     @moduledoc "Installs AshPostgres. Should be run with `mix igniter.install ash_postgres`"
     @shortdoc @moduledoc
-    require Igniter.Code.Common
     require Igniter.Code.Function
     use Igniter.Mix.Task
 

--- a/lib/resource_generator/resource_generator.ex
+++ b/lib/resource_generator/resource_generator.ex
@@ -728,7 +728,7 @@ if Code.ensure_loaded?(Igniter) do
     defp custom_indexes(table_spec, true) do
       table_spec.indexes
       |> Enum.reject(fn index ->
-        !index.unique? || (&index_as_identity?/1) ||
+        !index.unique? || index_as_identity?(index) ||
           Enum.any?(index.columns, &String.contains?(&1, "("))
       end)
       |> case do

--- a/test/constraint_test.exs
+++ b/test/constraint_test.exs
@@ -7,8 +7,6 @@ defmodule AshPostgres.ConstraintTest do
   use AshPostgres.RepoCase, async: false
   alias AshPostgres.Test.Post
 
-  require Ash.Query
-
   test "constraint messages are properly raised" do
     assert_raise Ash.Error.Invalid, ~r/yo, bad price/, fn ->
       Post

--- a/test/create_policy_filter_test.exs
+++ b/test/create_policy_filter_test.exs
@@ -19,7 +19,6 @@ defmodule AshPostgres.Test.CreatePolicyFilterTest do
   """
 
   use AshPostgres.RepoCase, async: false
-  require Ash.Query
 
   defmodule Domain do
     use Ash.Domain

--- a/test/custom_index_test.exs
+++ b/test/custom_index_test.exs
@@ -6,8 +6,6 @@ defmodule AshPostgres.Test.CustomIndexTest do
   use AshPostgres.RepoCase, async: false
   alias AshPostgres.Test.Post
 
-  require Ash.Query
-
   test "unique constraint errors are properly caught" do
     Post
     |> Ash.Changeset.for_create(:create, %{

--- a/test/cve/empty_atomic_non_bulk_actions_policy_bypass_test.exs
+++ b/test/cve/empty_atomic_non_bulk_actions_policy_bypass_test.exs
@@ -12,8 +12,6 @@ defmodule AshPostgres.EmptyAtomicNonBulkActionsPolicyBypassTest do
 
   alias AshPostgres.Test.PostWithEmptyUpdate
 
-  require Ash.Query
-
   test "a forbidden error is appropriately raised on atomic upgraded, empty, non-bulk actions" do
     post =
       PostWithEmptyUpdate

--- a/test/dev_migrations_test.exs
+++ b/test/dev_migrations_test.exs
@@ -7,8 +7,6 @@ defmodule AshPostgres.DevMigrationsTest do
   @moduletag :migration
   @moduletag :tmp_dir
 
-  require Logger
-
   alias Ecto.Adapters.SQL.Sandbox
 
   setup %{tmp_dir: tmp_dir} do

--- a/test/ecto_compatibility_test.exs
+++ b/test/ecto_compatibility_test.exs
@@ -4,7 +4,6 @@
 
 defmodule AshPostgres.EctoCompatibilityTest do
   use AshPostgres.RepoCase, async: false
-  require Ash.Query
 
   test "call Ecto.Repo.insert! via Ash Repo" do
     org =

--- a/test/enum_test.exs
+++ b/test/enum_test.exs
@@ -7,8 +7,6 @@ defmodule AshPostgres.EnumTest do
   use AshPostgres.RepoCase, async: false
   alias AshPostgres.Test.Post
 
-  require Ash.Query
-
   test "valid values are properly inserted" do
     Post
     |> Ash.Changeset.for_create(:create, %{title: "title", status: :open})

--- a/test/filter_child_relationship_by_parent_relationship_test.exs
+++ b/test/filter_child_relationship_by_parent_relationship_test.exs
@@ -6,8 +6,6 @@ defmodule AshPostgres.Test.Support.Relationships.FilterChileRelationshipByParent
   use AshPostgres.RepoCase, async: false
   alias AshPostgres.Test.{Comment, Post}
 
-  require Ash.Query
-
   describe "loading ratings of a comment filtered by a post" do
     setup do
       post =

--- a/test/filter_field_policy_test.exs
+++ b/test/filter_field_policy_test.exs
@@ -7,8 +7,6 @@ defmodule FilterFieldPolicyTest do
 
   alias AshPostgres.Test.{Organization, Post, User}
 
-  require Ash.Query
-
   test "filter uses the correct field policies when exanding refs" do
     organization =
       Organization

--- a/test/immutable_raise_error_test.exs
+++ b/test/immutable_raise_error_test.exs
@@ -7,8 +7,6 @@ defmodule AshPostgres.ImmutableRaiseErrorTest do
 
   alias AshPostgres.Test.ImmutableErrorTester
 
-  require Ash.Query
-
   setup do
     original = Application.get_env(:ash_postgres, :test_repo_use_immutable_errors?)
     Application.put_env(:ash_postgres, :test_repo_use_immutable_errors?, true)

--- a/test/multi_domain_calculations_test.exs
+++ b/test/multi_domain_calculations_test.exs
@@ -5,8 +5,6 @@
 defmodule AshPostgres.Test.MultiDomainCalculationsTest do
   use AshPostgres.RepoCase, async: false
 
-  require Ash.Query
-
   test "total is returned correctly" do
     item =
       AshPostgres.Test.MultiDomainCalculations.DomainOne.Item

--- a/test/parent_sort_test.exs
+++ b/test/parent_sort_test.exs
@@ -7,8 +7,6 @@ defmodule AshPostgres.Test.ParentSortTest do
 
   alias AshPostgres.Test.{Organization, Post, User}
 
-  require Ash.Query
-
   test "can reference parent field when declaring default sort in has_many no_attributes? relationship" do
     organization =
       Organization

--- a/test/polymorphism_test.exs
+++ b/test/polymorphism_test.exs
@@ -6,8 +6,6 @@ defmodule AshPostgres.PolymorphismTest do
   use AshPostgres.RepoCase, async: false
   alias AshPostgres.Test.{Label, Post, Rating}
 
-  require Ash.Query
-
   test "you can create related data" do
     Post
     |> Ash.Changeset.for_create(:create, rating: %{score: 10})

--- a/test/primary_key_test.exs
+++ b/test/primary_key_test.exs
@@ -7,8 +7,6 @@ defmodule AshPostgres.Test.PrimaryKeyTest do
   use AshPostgres.RepoCase, async: false
   alias AshPostgres.Test.{IntegerPost, Post, PostView}
 
-  require Ash.Query
-
   test "creates record with integer primary key" do
     assert %IntegerPost{} =
              IntegerPost |> Ash.Changeset.for_create(:create, %{title: "title"}) |> Ash.create!()

--- a/test/select_test.exs
+++ b/test/select_test.exs
@@ -7,8 +7,6 @@ defmodule AshPostgres.SelectTest do
   use AshPostgres.RepoCase, async: false
   alias AshPostgres.Test.Post
 
-  require Ash.Query
-
   test "values not selected in the query are not present in the response" do
     Post
     |> Ash.Changeset.for_create(:create, %{title: "title"})

--- a/test/support/concat.ex
+++ b/test/support/concat.ex
@@ -5,7 +5,6 @@
 defmodule AshPostgres.Test.Concat do
   @moduledoc false
   use Ash.Resource.Calculation
-  require Ash.Query
 
   def init(opts) do
     if opts[:keys] && is_list(opts[:keys]) && Enum.all?(opts[:keys], &is_atom/1) do

--- a/test/support/resources/post_tag.ex
+++ b/test/support/resources/post_tag.ex
@@ -8,8 +8,6 @@ defmodule AshPostgres.Test.PostTag do
     domain: AshPostgres.Test.Domain,
     data_layer: AshPostgres.DataLayer
 
-  require Ash.Sort
-
   postgres do
     table "post_tags"
     repo AshPostgres.TestRepo

--- a/test/support/resources/post_with_empty_update.ex
+++ b/test/support/resources/post_with_empty_update.ex
@@ -11,8 +11,6 @@ defmodule AshPostgres.Test.PostWithEmptyUpdate do
       Ash.Policy.Authorizer
     ]
 
-  require Ash.Sort
-
   policies do
     policy action(:empty_update) do
       # force visiting the database

--- a/test/support/resources/tag.ex
+++ b/test/support/resources/tag.ex
@@ -8,8 +8,6 @@ defmodule AshPostgres.Test.Tag do
     domain: AshPostgres.Test.Domain,
     data_layer: AshPostgres.DataLayer
 
-  require Ash.Sort
-
   postgres do
     table "tags"
     repo AshPostgres.TestRepo

--- a/test/support/types/response.ex
+++ b/test/support/types/response.ex
@@ -48,7 +48,7 @@ defmodule AshPostgres.Test.Types.Response do
     else
       case cast_input(new_value, constraints) do
         {:ok, value} -> {:atomic, value}
-        {:error, error} -> {:error, error}
+        :error -> :error
       end
     end
   end

--- a/test/tenant_scoped_upsert_test.exs
+++ b/test/tenant_scoped_upsert_test.exs
@@ -20,7 +20,6 @@ defmodule AshPostgres.Test.TenantScopedUpsertTest do
   """
 
   use AshPostgres.RepoCase, async: false
-  require Ash.Query
 
   defmodule Domain do
     use Ash.Domain

--- a/test/transaction_test.exs
+++ b/test/transaction_test.exs
@@ -6,8 +6,6 @@ defmodule AshPostgres.Test.TransactionTest do
   use AshPostgres.RepoCase, async: false
   alias AshPostgres.Test.Post
 
-  require Ash.Query
-
   test "after_transaction hooks are invoked on failure" do
     assert_raise Ash.Error.Unknown, ~r/something bad happened/, fn ->
       Post

--- a/test/unique_identity_test.exs
+++ b/test/unique_identity_test.exs
@@ -7,8 +7,6 @@ defmodule AshPostgres.Test.UniqueIdentityTest do
   alias AshPostgres.Test.Organization
   alias AshPostgres.Test.Post
 
-  require Ash.Query
-
   test "unique constraint errors are properly caught" do
     post =
       Post

--- a/test/update_many_test.exs
+++ b/test/update_many_test.exs
@@ -6,8 +6,6 @@ defmodule AshPostgres.Test.UpdateManyTest do
   use AshPostgres.RepoCase, async: false
   alias AshPostgres.Test.Post
 
-  require Ash.Query
-
   # `update_many` is implemented as a single SQL MERGE, which requires PostgreSQL 17.
   @moduletag :postgres_17
 

--- a/test/upsert_test.exs
+++ b/test/upsert_test.exs
@@ -6,8 +6,6 @@ defmodule AshPostgres.Test.UpsertTest do
   use AshPostgres.RepoCase, async: false
   alias AshPostgres.Test.Post
 
-  require Ash.Query
-
   test "empty upserts" do
     id = Ash.UUID.generate()
 


### PR DESCRIPTION
# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [x] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

## Summary
Is a part of this issue: https://github.com/ash-project/ash/issues/2745

- Update the project `.tool-versions` to Elixir 1.20
- Clean up compiler/type warnings surfaced by Elixir 1.20
- Remove unused test/support `require`s so the build suite runs cleanly
- Fix custom test type error handling to match its actual `cast_input/2` return shape

## Verified

- `mix test` passes
- `mix check` passes