### PR TITLE
fix: set tenant on destroy so exists() subqueries resolve against the tenant schema

### DIFF
--- a/lib/data_layer.ex
+++ b/lib/data_layer.ex
@@ -4142,6 +4142,28 @@ defmodule AshPostgres.DataLayer do
         changeset.context
       )
       |> pkey_filter(record)
+      |> then(fn query ->
+        if changeset.tenant do
+          query =
+            set_tenant(resource, query, changeset.tenant)
+            |> elem(1)
+
+          Map.update!(query, :__ash_bindings__, fn bindings ->
+            Map.update(
+              bindings,
+              :context,
+              %{private: %{tenant: changeset.tenant}},
+              fn context ->
+                context
+                |> Map.put_new(:private, %{})
+                |> put_in([:private, :tenant], changeset.tenant)
+              end
+            )
+          end)
+        else
+          query
+        end
+      end)
 
     repo = AshSql.dynamic_repo(resource, AshPostgres.SqlImplementation, changeset)
 

--- a/test/multitenancy_test.exs
+++ b/test/multitenancy_test.exs
@@ -98,6 +98,21 @@ defmodule AshPostgres.Test.MultitenancyTest do
     |> Ash.update!()
   end
 
+  test "context multitenancy sets the tenant on exists() subqueries when destroying", %{
+    org1: org1
+  } do
+    post =
+      Post
+      |> Ash.Changeset.for_create(:create, %{name: "foo"}, tenant: org1)
+      |> Ash.create!()
+
+    post
+    |> Ash.Changeset.for_destroy(:destroy_with_exists, %{}, tenant: org1)
+    |> Ash.destroy!()
+
+    assert Post |> Ash.Query.set_tenant(org1) |> Ash.read!() == []
+  end
+
   test "attribute multitenancy is set on creation" do
     uuid = Ash.UUID.generate()
 

--- a/test/support/multitenancy/resources/post.ex
+++ b/test/support/multitenancy/resources/post.ex
@@ -31,6 +31,10 @@ defmodule AshPostgres.MultitenancyTest.Post do
     defaults([:create, :read, :update, :destroy])
 
     update(:update_with_policy)
+
+    destroy(:destroy_with_exists) do
+      change(filter(expr(exists(self, true))))
+    end
   end
 
   postgres do


### PR DESCRIPTION
## Problem

Fixes #787.

Under context (schema) multitenancy, an `exists()` subquery in a **destroy** action's atomic filter/validation compiles against the `public` schema instead of the tenant schema, raising `42P01 undefined_table` (or silently matching the wrong schema if a same-named public table exists). The identical `exists()` on an **update** action resolves correctly.

## Fix

`AshPostgres.DataLayer.destroy/2` hand-builds its Ecto query from `changeset.context`. `Ash.Actions.Helpers.add_context/2` seeds the private context with `actor`/`authorize?`/`tracer` but not the tenant, so when the destroy filter is compiled via `filter/3` → `AshSql.Join.related_subquery` (which reads `query.__ash_bindings__.context[:private][:tenant]`), the tenant is `nil` and the subquery falls back to `public`.

Update escapes this only because its `exists()` compiles through the atomics path (`__ash_bindings__.tenant`). Bulk `destroy_query/4` is unaffected — it routes through `Ash.Query.data_layer_query/2`, which already seeds `context.private.tenant`.

The fix propagates the tenant to the query (prefix + `__tenant__` via `set_tenant/3`) and seeds `context.private.tenant` into the bindings the same way `Ash.Query.data_layer_query/2` does for reads/bulk.

## Tests

Added `destroy(:destroy_with_exists)` on the multitenancy `Post` test resource (mirroring the existing `update_with_policy`) and a regression test in `test/multitenancy_test.exs`. Confirmed red (`42P01` against `public.multitenant_posts`) before the fix, green after.

Full suite: 850 tests + 2 doctests + 2 properties, 0 failures. `mix format` and `mix ash_postgres.generate_migrations --check` clean.

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
