### PR TITLE
fix: warn when resources are skipped due to migrate?: false during mi…

### DIFF
--- a/lib/migration_generator/migration_generator.ex
+++ b/lib/migration_generator/migration_generator.ex
@@ -95,7 +95,9 @@ defmodule AshPostgres.MigrationGenerator do
 
             Note: Some resources have `migrate?` set to `false` and were skipped.
 
-            If you expected migrations to be generated for them, remove `migrate?(false)` from their `postgres` block. Resources generated with `mix ash_postgres.gen.resources --no-migrations` have `migrate?` set to `false` by default.
+            If you expected migrations to be generated for them, remove `migrate?(false)`
+            from their `postgres` block. Resources generated with `mix ash_postgres.gen.resources
+            --no-migrations` have `migrate?` set to `false` by default.
             """)
           end
         end

--- a/lib/migration_generator/migration_generator.ex
+++ b/lib/migration_generator/migration_generator.ex
@@ -90,14 +90,10 @@ defmodule AshPostgres.MigrationGenerator do
               "No changes detected, so no migrations or snapshots have been created."
             )
           else
-            unmanaged_names =
-              unmanaged_resources
-              |> Enum.map_join(", ", &inspect/1)
-
             Mix.shell().info("""
             No changes detected, so no migrations or snapshots have been created.
 
-            Note: the following resources have `migrate?` set to `false` and were skipped: #{unmanaged_names}.
+            Note: Some resources have `migrate?` set to `false` and were skipped.
 
             If you expected migrations to be generated for them, remove `migrate?(false)` from their `postgres` block. Resources generated with `mix ash_postgres.gen.resources --no-migrations` have `migrate?` set to `false` by default.
             """)

--- a/lib/migration_generator/migration_generator.ex
+++ b/lib/migration_generator/migration_generator.ex
@@ -85,9 +85,23 @@ defmodule AshPostgres.MigrationGenerator do
     case extension_migration_files ++ tenant_migration_files ++ migration_files do
       [] ->
         if !opts.check || opts.dry_run do
-          Mix.shell().info(
-            "No changes detected, so no migrations or snapshots have been created."
-          )
+          if Enum.empty?(unmanaged_resources) do
+            Mix.shell().info(
+              "No changes detected, so no migrations or snapshots have been created."
+            )
+          else
+            unmanaged_names =
+              unmanaged_resources
+              |> Enum.map_join(", ", &inspect/1)
+
+            Mix.shell().info("""
+            No changes detected, so no migrations or snapshots have been created.
+
+            Note: the following resources have `migrate?` set to `false` and were skipped: #{unmanaged_names}.
+
+            If you expected migrations to be generated for them, remove `migrate?(false)` from their `postgres` block. Resources generated with `mix ash_postgres.gen.resources --no-migrations` have `migrate?` set to `false` by default.
+            """)
+          end
         end
 
         :ok

--- a/test/migration_generator_test.exs
+++ b/test/migration_generator_test.exs
@@ -6816,4 +6816,55 @@ defmodule AshPostgres.MigrationGeneratorTest do
       refute up =~ "references(:referenced_schema_move_authors"
     end
   end
+  describe "resources with migrate? false (#585)" do
+    test "warns that resources were skipped due to migrate? false", %{
+      snapshot_path: snapshot_path,
+      migration_path: migration_path
+    } do
+      defresource SkippedMigrateResource do
+        postgres do
+          table "skipped_migrate_resource"
+          repo AshPostgres.TestRepo
+          migrate? false
+        end
+
+        actions do
+          defaults([:read, :create])
+        end
+
+        attributes do
+          uuid_primary_key(:id)
+        end
+      end
+
+      defdomain([SkippedMigrateResource])
+
+      # First run: creates extension migrations (unrelated to our resource)
+      AshPostgres.MigrationGenerator.generate(Domain,
+        snapshot_path: snapshot_path,
+        migration_path: migration_path,
+        quiet: false,
+        format: false,
+        auto_name: true
+      )
+
+      flush_mix_shell()
+
+      # Second run: extensions already exist, so only the migrate? false
+      # resource remains — which is skipped, producing "No changes detected"
+      AshPostgres.MigrationGenerator.generate(Domain,
+        snapshot_path: snapshot_path,
+        migration_path: migration_path,
+        quiet: false,
+        format: false,
+        auto_name: true
+      )
+
+      output = shell_output()
+
+      assert output =~ "No changes detected"
+      assert output =~ "migrate?"
+      assert output =~ "SkippedMigrateResource"
+    end
+  end
 end


### PR DESCRIPTION
## Problem

Fixes #585.

The issue here was that after generating the domain from the tables using mix ash_postgres.gen.resources, no unique migrations were being generated. This lead to cryptic errors (no migrations could be generated) to the user, who expected unique migration names to be generated. 

## Fix
After a lot of testing and investigation, I found out that there was no bug and the process was working as expected, as these resources had the atribbute migrate?(false). In order to let the user understand the situation they are in, I have chosen to enhance the "No changes detected" message, and let the user know about the migrate?(false) attribute. In addition to this, a regression test was added covering this new previously untested path.

## Tests

Passed the migrate tests (test.drop, test.create, test.migrate) and mix test. 

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
