### PR TITLE
feat: allow custom indexes to exclude base filters

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -23,6 +23,7 @@ spark_locals_without_parens = [
   identity_wheres_to_sql: 1,
   ignore?: 1,
   include: 1,
+  include_base_filter?: 1,
   index: 1,
   index: 2,
   index?: 1,

--- a/lib/custom_index.ex
+++ b/lib/custom_index.ex
@@ -21,7 +21,8 @@ defmodule AshPostgres.CustomIndex do
     :include,
     :nulls_distinct,
     :message,
-    :all_tenants?
+    :all_tenants?,
+    :include_base_filter?
   ]
 
   defstruct @fields ++ [:__spark_metadata__]
@@ -93,6 +94,11 @@ defmodule AshPostgres.CustomIndex do
       type: :boolean,
       default: false,
       doc: "Whether or not the index should factor in the multitenancy attribute or not."
+    ],
+    include_base_filter?: [
+      type: :boolean,
+      default: true,
+      doc: "Whether or not the resource base filter should be included in the index predicate."
     ]
   ]
 

--- a/lib/migration_generator/migration_generator.ex
+++ b/lib/migration_generator/migration_generator.ex
@@ -4765,6 +4765,7 @@ defmodule AshPostgres.MigrationGenerator do
       |> Map.put_new(:nulls_distinct, true)
       |> Map.put_new(:message, nil)
       |> Map.put_new(:all_tenants?, false)
+      |> Map.put_new(:include_base_filter?, true)
     end)
   end
 

--- a/lib/migration_generator/operation.ex
+++ b/lib/migration_generator/operation.ex
@@ -1104,10 +1104,14 @@ defmodule AshPostgres.MigrationGenerator.Operation do
         |> Enum.map(&AshPostgres.CustomIndex.field_for_migration/1)
 
       index =
-        case {index.where, base_filter} do
-          {_where, nil} -> index
-          {nil, base_filter} -> %{index | where: base_filter}
-          {where, base_filter} -> %{index | where: base_filter <> " AND " <> where}
+        if index.include_base_filter? do
+          case {index.where, base_filter} do
+            {_where, nil} -> index
+            {nil, base_filter} -> %{index | where: base_filter}
+            {where, base_filter} -> %{index | where: base_filter <> " AND " <> where}
+          end
+        else
+          index
         end
 
       opts =

--- a/test/custom_index_test.exs
+++ b/test/custom_index_test.exs
@@ -38,4 +38,22 @@ defmodule AshPostgres.Test.CustomIndexTest do
 
     assert index.error_fields == [:tenant_id, :occurred_at]
   end
+
+  test "custom indexes can exclude the resource base filter" do
+    operation = %AshPostgres.MigrationGenerator.Operation.AddCustomIndex{
+      table: "events",
+      schema: nil,
+      base_filter: "archived_at IS NULL",
+      multitenancy: %{strategy: nil},
+      index: %AshPostgres.CustomIndex{
+        fields: [:account_id],
+        name: "events_account_id_fkey_index",
+        nulls_distinct: true,
+        include_base_filter?: false
+      }
+    }
+
+    assert AshPostgres.MigrationGenerator.Operation.AddCustomIndex.up(operation) ==
+             ~S|create index(:events, [:account_id], name: "events_account_id_fkey_index")|
+  end
 end


### PR DESCRIPTION
## Summary

Adds an `include_base_filter?` option to PostgreSQL custom indexes.

It defaults to `true`, preserving the existing behavior. Setting it to `false` creates an index without merging the resource's `base_filter_sql` into its predicate.

## Motivation

Most custom indexes should inherit the resource base filter. Some indexes need to cover every row.

For example, when a referenced row is updated or deleted, PostgreSQL looks for matching rows in the referencing table. A partial index that excludes archived rows cannot support that lookup across all referencing rows.

Given:

```elixir
base_filter_sql "archived_at IS NULL"
```

a custom index can opt out of that predicate:

```elixir
custom_indexes do
  index [:account_id],
    name: "events_account_id_fkey_index",
    include_base_filter?: false
end
```

This generates:

```elixir
create index(
  :events,
  [:account_id],
  name: "events_account_id_fkey_index"
)
```

instead of:

```elixir
create index(
  :events,
  [:account_id],
  name: "events_account_id_fkey_index",
  where: "archived_at IS NULL"
)
```

## Compatibility

- Existing custom indexes continue to include the base filter.
- Older snapshots default to `include_base_filter?: true` when loaded.
- Newly generated snapshots include the option explicitly.
- Changing the option generates the required index rewrite.

## Tests

Added unit coverage confirming that `include_base_filter?: false` omits the resource base filter from the generated index.

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [X] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [X] Documentation changes
- [X] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
