### PR TITLE
fix: fix generated reference type value for identity and bigserial

### DIFF
--- a/lib/migration_generator/operation.ex
+++ b/lib/migration_generator/operation.ex
@@ -77,9 +77,9 @@ defmodule AshPostgres.MigrationGenerator.Operation do
       :bigint
     end
 
-    def reference_type(%{type: :identity}, _), do: ":identity"
+    def reference_type(%{type: :identity}, _), do: :identity
 
-    def reference_type(%{type: :integer, default: "nil", generated?: true}, _), do: ":bigserial"
+    def reference_type(%{type: :integer, default: "nil", generated?: true}, _), do: :bigserial
 
     def reference_type(%{type: type}, _), do: type
 


### PR DESCRIPTION
Don't know how it worked before but all `reference_type` calls are wrapped in `inspect` and if the value is `":bigserial"` instead of `:bigserial` then you end up with `type: ":bigserial"` in a generated migration and for that Ecto will throw an unsupported type error...
