### PR TITLE
chore: Add (currently failing) test for aggregates ignoring relationship limit

### DIFF
--- a/test/aggregate_test.exs
+++ b/test/aggregate_test.exs
@@ -316,6 +316,29 @@ defmodule AshSql.AggregateTest do
     end
   end
 
+  describe "aggregates over a relationship with a limit" do
+    test "respect the relationship's limit and sort" do
+      comment =
+        Comment
+        |> Ash.Changeset.for_create(:create, %{title: "title"})
+        |> Ash.create!()
+
+      for score <- 1..5 do
+        Rating
+        |> Ash.Changeset.for_create(:create, %{score: score, resource_id: comment.id})
+        |> Ash.create!(context: %{data_layer: %{table: "comment_ratings"}})
+      end
+
+      # top_ratings has `limit: 2, sort: [score: :desc]`, so aggregates over it
+      # should only see the top two scores, [5, 4] — not all five ratings.
+      assert %{count_of_top_ratings: 2, top_rating_scores: [5, 4]} =
+               Comment
+               |> Ash.Query.filter(id == ^comment.id)
+               |> Ash.Query.load([:count_of_top_ratings, :top_rating_scores])
+               |> Ash.read_one!()
+    end
+  end
+
   describe "count" do
     test "with no related data it returns 0" do
       post =

--- a/test/support/resources/comment.ex
+++ b/test/support/resources/comment.ex
@@ -138,6 +138,10 @@ defmodule AshPostgres.Test.Comment do
     end
 
     count(:count_of_ratings, :ratings)
+
+    # top_ratings has `limit: 2` — aggregates over it should respect that limit.
+    count(:count_of_top_ratings, :top_ratings)
+    list(:top_rating_scores, :top_ratings, :score)
   end
 
   calculations do


### PR DESCRIPTION
An aggregate over a `has_many` that declares a limit counts/lists *all* related rows instead of the limited top-N. `count(top_5_posts)` should be bounded to 5.

**Reproduction** (failing test on main over the existing `Comment.top_ratings`, which is `limit: 2, sort: [score: :desc]`):

```elixir
# aggregates on Comment:
count(:count_of_top_ratings, :top_ratings)
list(:top_rating_scores, :top_ratings, :score)

# create 5 ratings (scores 1..5), then:
assert %{count_of_top_ratings: 2, top_rating_scores: [5, 4]} = ...
# actual: count_of_top_ratings: 5, top_rating_scores: [5,4,3,2,1]
```

**Root cause (`ash_sql/lib/aggregate.ex`):** in `get_subquery/…` (the relationship-path clause), `on_subquery` runs `select_all_aggregates` (the `GROUP BY` + `count/array_agg`) before `related_subquery` calls `limit_from_many` (`join.ex:397`). So any limit is applied *after* grouping — it caps the number of groups, not rows-per-group. The generated SQL puts `LIMIT` after `GROUP BY resource_id` inside the lateral join.

**What the fix needs:** when the source relationship has `limit/offset`, the correlated+sorted rows must be wrapped in an inner `… ORDER BY <rel.sort> LIMIT n` subquery *before* the aggregate folds them:

```sql
SELECT resource_id, count(*)
FROM (SELECT * FROM comment_ratings WHERE <parent-corr> ORDER BY score DESC LIMIT 2) sc0
GROUP BY resource_id
```

**Attempt / how far it got:** gating on `rel.limit`, I passed `sort?: true` and split the default `apply_relationship_subquery` to build the inner correlated+ordered+limited subquery, then group outside. The **inner subquery builds correctly** (verified: `parent_as` correlation + `ORDER BY score DESC + LIMIT`). The blocker is composing the grouped **outer** level into the `left_lateral_join` — Ecto raises "invalid query was interpolated in a join"; the added nesting level needs the `as/parent_as` + `start_bindings_at/current` binding bookkeeping to be rebased, which the single-level aggregate path doesn't currently do.

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [x] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
