### PR TITLE
fix: return upsert identity keys so bulk upserts don't drop records

### DIFF
--- a/lib/data_layer.ex
+++ b/lib/data_layer.ex
@@ -2286,6 +2286,25 @@ defmodule AshPostgres.DataLayer do
             fields -> fields
           end
 
+        # Upserts pair each returned row back up with its changeset by the upsert identity's
+        # keys, so those keys have to be read back even when the action's select doesn't ask
+        # for them - otherwise nothing correlates and every record is dropped from the
+        # result while still being written. `Ash.Actions.Helpers.select/2` masks the extra
+        # fields out of the records afterwards, so this doesn't widen what callers observe.
+        # Identity keys that aren't attributes (an identity over a calculation, e.g.
+        # `upper(thing)`) have no column to return and are left out.
+        returning =
+          if options[:upsert?] && is_list(returning) do
+            correlation_keys =
+              resource
+              |> upsert_correlation_keys(options)
+              |> Enum.filter(&Ash.Resource.Info.attribute(resource, &1))
+
+            Enum.uniq(returning ++ correlation_keys)
+          else
+            returning
+          end
+
         Keyword.put(opts, :returning, returning)
       else
         opts
@@ -2403,7 +2422,7 @@ defmodule AshPostgres.DataLayer do
         end
 
       identity = options[:identity]
-      keys = Map.get(identity || %{}, :keys) || Ash.Resource.Info.primary_key(resource)
+      keys = upsert_correlation_keys(resource, options)
 
       # if it's single the return_skipped_upsert? is handled at the
       # call site https://github.com/ash-project/ash_postgres/blob/0b21d4a99cc3f6d8676947e291ac9b9d57ad6e2e/lib/data_layer.ex#L3046-L3046
@@ -2558,6 +2577,13 @@ defmodule AshPostgres.DataLayer do
           resource
         )
     end
+  end
+
+  # The keys `bulk_create/3` uses to pair returned rows back up with their changesets when
+  # upserting. Positional correlation isn't an option there: the rows PostgreSQL returns are
+  # neither guaranteed to be in input order nor guaranteed to be one per input.
+  defp upsert_correlation_keys(resource, options) do
+    Map.get(options[:identity] || %{}, :keys) || Ash.Resource.Info.primary_key(resource)
   end
 
   @impl true

--- a/test/bulk_create_test.exs
+++ b/test/bulk_create_test.exs
@@ -323,6 +323,64 @@ defmodule AshPostgres.BulkCreateTest do
                end)
     end
 
+    # Bulk upserts correlate the returned rows back to their changesets by the upsert
+    # identity's keys, so those keys have to be read back even when the action's select
+    # doesn't ask for them - otherwise no row correlates and every record is silently
+    # dropped from the result while still being written to the database.
+    #
+    # `:upsert_with_no_filter` declares no changes or notifiers, so its `action_select`
+    # is just the primary key; an explicit `select` therefore can't widen it to include
+    # `:uniq_if_contains_foo`. `select: []` is what `Ash.Reactor`'s `bulk_create` step
+    # passes.
+    test "bulk upsert returns inserted records when select excludes the identity keys" do
+      assert %Ash.BulkResult{status: :success, records: records} =
+               Ash.bulk_create(
+                 [
+                   %{title: "fredfoo", uniq_if_contains_foo: "1foo", price: 10},
+                   %{title: "georgefoo", uniq_if_contains_foo: "2foo", price: 20}
+                 ],
+                 Post,
+                 :upsert_with_no_filter,
+                 return_records?: true,
+                 return_errors?: true,
+                 select: []
+               )
+
+      assert length(records) == 2
+      assert Enum.all?(records, & &1.id)
+
+      assert [10, 20] == Post |> Ash.read!() |> Enum.map(& &1.price) |> Enum.sort()
+    end
+
+    test "bulk upsert returns updated records when select excludes the identity keys" do
+      Ash.bulk_create!(
+        [
+          %{title: "fredfoo", uniq_if_contains_foo: "1foo", price: 10},
+          %{title: "georgefoo", uniq_if_contains_foo: "2foo", price: 20}
+        ],
+        Post,
+        :create
+      )
+
+      assert %Ash.BulkResult{status: :success, records: records} =
+               Ash.bulk_create(
+                 [
+                   %{title: "fredfoo", uniq_if_contains_foo: "1foo", price: 1000},
+                   %{title: "georgefoo", uniq_if_contains_foo: "2foo", price: 20_000}
+                 ],
+                 Post,
+                 :upsert_with_no_filter,
+                 return_records?: true,
+                 return_errors?: true,
+                 select: [:id]
+               )
+
+      assert length(records) == 2
+      assert Enum.all?(records, & &1.id)
+
+      assert [1000, 20_000] == Post |> Ash.read!() |> Enum.map(& &1.price) |> Enum.sort()
+    end
+
     test "bulk upsert returns skipped records with return_skipped_upsert?" do
       assert [
                {:ok, %{title: "fredfoo", uniq_if_contains_foo: "1foo", price: 10}},


### PR DESCRIPTION
My dependabot branch for the ash_postgres update from 2.10.0 to 2.11.0 failed CI. 

I send my AI to create a fix.

I will read the surrunding code until I can verify the AI code but open this as draft until then.
# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
