### PR TITLE
test: cover bulk upsert dropping records when select excludes identity keys

### DIFF
--- a/test/bulk_create_test.exs
+++ b/test/bulk_create_test.exs
@@ -323,6 +323,64 @@ defmodule AshPostgres.BulkCreateTest do
                end)
     end
 
+    # Bulk upserts correlate the returned rows back to their changesets by the upsert
+    # identity's keys, so those keys have to be read back even when the action's select
+    # doesn't ask for them - otherwise no row correlates and every record is silently
+    # dropped from the result while still being written to the database.
+    #
+    # `:upsert_with_no_filter` declares no changes or notifiers, so its `action_select`
+    # is just the primary key; an explicit `select` therefore can't widen it to include
+    # `:uniq_if_contains_foo`. `select: []` is what `Ash.Reactor`'s `bulk_create` step
+    # passes.
+    test "bulk upsert returns inserted records when select excludes the identity keys" do
+      assert %Ash.BulkResult{status: :success, records: records} =
+               Ash.bulk_create(
+                 [
+                   %{title: "fredfoo", uniq_if_contains_foo: "1foo", price: 10},
+                   %{title: "georgefoo", uniq_if_contains_foo: "2foo", price: 20}
+                 ],
+                 Post,
+                 :upsert_with_no_filter,
+                 return_records?: true,
+                 return_errors?: true,
+                 select: []
+               )
+
+      assert length(records) == 2
+      assert Enum.all?(records, & &1.id)
+
+      assert [10, 20] == Post |> Ash.read!() |> Enum.map(& &1.price) |> Enum.sort()
+    end
+
+    test "bulk upsert returns updated records when select excludes the identity keys" do
+      Ash.bulk_create!(
+        [
+          %{title: "fredfoo", uniq_if_contains_foo: "1foo", price: 10},
+          %{title: "georgefoo", uniq_if_contains_foo: "2foo", price: 20}
+        ],
+        Post,
+        :create
+      )
+
+      assert %Ash.BulkResult{status: :success, records: records} =
+               Ash.bulk_create(
+                 [
+                   %{title: "fredfoo", uniq_if_contains_foo: "1foo", price: 1000},
+                   %{title: "georgefoo", uniq_if_contains_foo: "2foo", price: 20_000}
+                 ],
+                 Post,
+                 :upsert_with_no_filter,
+                 return_records?: true,
+                 return_errors?: true,
+                 select: [:id]
+               )
+
+      assert length(records) == 2
+      assert Enum.all?(records, & &1.id)
+
+      assert [1000, 20_000] == Post |> Ash.read!() |> Enum.map(& &1.price) |> Enum.sort()
+    end
+
     test "bulk upsert returns skipped records with return_skipped_upsert?" do
       assert [
                {:ok, %{title: "fredfoo", uniq_if_contains_foo: "1foo", price: 10}},


### PR DESCRIPTION
On upsert the columns that need to be selected to match the updated rows with the rows from the database are not selected anymore so upsert result is empty even if the data is written into the db.

This is a regression that is related to https://github.com/ash-project/ash_postgres/pull/786 and https://github.com/ash-project/ash_postgres/pull/638

In my case, an upsert_identity with unique_index defines the upsert semantic already, so the select was left out and is filled by the upsert reactor with the empty list. But the unique index is constructed with two fields not only one like the test, i can add this as well?

My dependabot branch for the ash_postgres update from 2.10.0 to 2.11.0 failed CI
The tests reproduce a simplified version of the problem.



# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
