### PR TITLE
chore: add tests for ash_sql #243

### DIFF
--- a/test/combination_test.exs
+++ b/test/combination_test.exs
@@ -222,6 +222,34 @@ defmodule AshPostgres.CombinationTest do
       assert hd(result).title == "post1"
     end
 
+    test "a third combination part applies to the running result, not to the second part" do
+      for title <- ["alpha", "beta", "gamma", "delta"] do
+        Post
+        |> Ash.Changeset.for_create(:create, %{title: title})
+        |> Ash.create!()
+      end
+
+      # The parts are applied in the order given, so this is
+      # ({alpha, beta} ∪ {gamma}) ∩ {alpha, gamma}.
+      #
+      # Rendered as a flat SQL chain instead, INTERSECT would bind tighter than
+      # UNION and give {alpha, beta} ∪ ({gamma} ∩ {alpha, gamma}), which keeps
+      # beta. `delta` belongs to neither grouping, so a whole-table read cannot
+      # be mistaken for a pass.
+      result =
+        Post
+        |> Ash.Query.combination_of([
+          Ash.Query.Combination.base(filter: expr(title in ["alpha", "beta"])),
+          Ash.Query.Combination.union(filter: expr(title == "gamma")),
+          Ash.Query.Combination.intersect(filter: expr(title in ["alpha", "gamma"]))
+        ])
+        |> Ash.read!()
+        |> Enum.map(& &1.title)
+        |> Enum.sort()
+
+      assert result == ["alpha", "gamma"]
+    end
+
     test "combinations with multiple union_all" do
       Post
       |> Ash.Changeset.for_create(:create, %{title: "post1"})


### PR DESCRIPTION
# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [X] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [X] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

Reproduction/regression test for: https://github.com/ash-project/ash_sql/pull/244 (issue:
https://github.com/ash-project/ash_sql/issues/243).

`Ash.Query.combination_of/2` applies its parts in the order given, each to the result of
everything before it. `ash_sql` renders them as a flat chain of set operations, so SQL's own
precedence regroups a combination that spans more than one precedence level .
INTERSECT` binds tighter than `UNION`/`EXCEPT`. The query then answers differently here than it does under `Ash.DataLayer.Ets`.

The test adds a three-part case to `test/combination_test.exs`: `base`, `union`, then `intersect`,
where applying the parts in order and letting SQL regroup them give different answers. A fourth
record belongs to neither grouping, so reading the whole table cannot be mistaken for a pass.

```
against ash_sql 0.6.6      left:  ["alpha", "beta", "gamma"]
                           right: ["alpha", "gamma"]

with ash_sql#NNN           19 passed
```

Every existing combination test here stops at two parts, which is the one shape where the order
cannot be observed — two parts agree however they are grouped, and `union`/`except` share a
precedence in SQL so they agree too. That is why this has not surfaced.

⚠️ This test fails until ash_sql#244 lands and is released. Note also that `main` is currently red
independently of this: 11 tests in `AshPostgres.AggregateReadActionTest` fail on `fc165f3e`
against released `ash_sql` 0.6.6, unrelated to combinations or to this change.