### PR TITLE
fix: return upsert identity keys and correlate on the full key set so bulk upserts don't drop
    records

### DIFF
--- a/lib/data_layer.ex
+++ b/lib/data_layer.ex
@@ -2443,7 +2443,7 @@ defmodule AshPostgres.DataLayer do
             |> Enum.filter(fn changeset ->
               not Map.has_key?(
                 results_by_identity,
-                Map.take(changeset.attributes, keys)
+                changeset_correlation_key(changeset, keys)
               )
             end)
             |> Enum.map(fn changeset ->
@@ -2483,9 +2483,7 @@ defmodule AshPostgres.DataLayer do
           results =
             changesets
             |> Enum.map(fn changeset ->
-              identity =
-                changeset.attributes
-                |> Map.take(keys)
+              identity = changeset_correlation_key(changeset, keys)
 
               Map.get(results_by_identity, identity, Map.get(skipped_upserts, identity))
             end)
@@ -2516,9 +2514,7 @@ defmodule AshPostgres.DataLayer do
               if options[:upsert?] do
                 changesets
                 |> Enum.map(fn changeset ->
-                  identity =
-                    changeset.attributes
-                    |> Map.take(keys)
+                  identity = changeset_correlation_key(changeset, keys)
 
                   result_for_changeset = Map.get(results_by_identity, identity)
 
@@ -2584,6 +2580,15 @@ defmodule AshPostgres.DataLayer do
   # neither guaranteed to be in input order nor guaranteed to be one per input.
   defp upsert_correlation_keys(resource, options) do
     Map.get(options[:identity] || %{}, :keys) || Ash.Resource.Info.primary_key(resource)
+  end
+
+  # The correlation key for a changeset. `Map.take/2` would drop identity keys the changeset
+  # never set (a nullable field left `nil`, common with `nils_distinct?: false` identities),
+  # producing a key with fewer fields than the returned row's `Map.take(row, keys)` - so it
+  # would never match and the record would be dropped. Build the key over every identity key,
+  # defaulting the unset ones to `nil`, so both sides have the same shape.
+  defp changeset_correlation_key(changeset, keys) do
+    Map.new(keys, fn key -> {key, Map.get(changeset.attributes, key)} end)
   end
 
   @impl true

--- a/lib/data_layer.ex
+++ b/lib/data_layer.ex
@@ -2286,6 +2286,25 @@ defmodule AshPostgres.DataLayer do
             fields -> fields
           end
 
+        # Upserts pair each returned row back up with its changeset by the upsert identity's
+        # keys, so those keys have to be read back even when the action's select doesn't ask
+        # for them - otherwise nothing correlates and every record is dropped from the
+        # result while still being written. `Ash.Actions.Helpers.select/2` masks the extra
+        # fields out of the records afterwards, so this doesn't widen what callers observe.
+        # Identity keys that aren't attributes (an identity over a calculation, e.g.
+        # `upper(thing)`) have no column to return and are left out.
+        returning =
+          if options[:upsert?] && is_list(returning) do
+            correlation_keys =
+              resource
+              |> upsert_correlation_keys(options)
+              |> Enum.filter(&Ash.Resource.Info.attribute(resource, &1))
+
+            Enum.uniq(returning ++ correlation_keys)
+          else
+            returning
+          end
+
         Keyword.put(opts, :returning, returning)
       else
         opts
@@ -2403,7 +2422,7 @@ defmodule AshPostgres.DataLayer do
         end
 
       identity = options[:identity]
-      keys = Map.get(identity || %{}, :keys) || Ash.Resource.Info.primary_key(resource)
+      keys = upsert_correlation_keys(resource, options)
 
       # if it's single the return_skipped_upsert? is handled at the
       # call site https://github.com/ash-project/ash_postgres/blob/0b21d4a99cc3f6d8676947e291ac9b9d57ad6e2e/lib/data_layer.ex#L3046-L3046
@@ -2558,6 +2577,13 @@ defmodule AshPostgres.DataLayer do
           resource
         )
     end
+  end
+
+  # The keys `bulk_create/3` uses to pair returned rows back up with their changesets when
+  # upserting. Positional correlation isn't an option there: the rows PostgreSQL returns are
+  # neither guaranteed to be in input order nor guaranteed to be one per input.
+  defp upsert_correlation_keys(resource, options) do
+    Map.get(options[:identity] || %{}, :keys) || Ash.Resource.Info.primary_key(resource)
   end
 
   @impl true

--- a/test/bulk_create_test.exs
+++ b/test/bulk_create_test.exs
@@ -323,6 +323,64 @@ defmodule AshPostgres.BulkCreateTest do
                end)
     end
 
+    # Bulk upserts correlate the returned rows back to their changesets by the upsert
+    # identity's keys, so those keys have to be read back even when the action's select
+    # doesn't ask for them - otherwise no row correlates and every record is silently
+    # dropped from the result while still being written to the database.
+    #
+    # `:upsert_with_no_filter` declares no changes or notifiers, so its `action_select`
+    # is just the primary key; an explicit `select` therefore can't widen it to include
+    # `:uniq_if_contains_foo`. `select: []` is what `Ash.Reactor`'s `bulk_create` step
+    # passes.
+    test "bulk upsert returns inserted records when select excludes the identity keys" do
+      assert %Ash.BulkResult{status: :success, records: records} =
+               Ash.bulk_create(
+                 [
+                   %{title: "fredfoo", uniq_if_contains_foo: "1foo", price: 10},
+                   %{title: "georgefoo", uniq_if_contains_foo: "2foo", price: 20}
+                 ],
+                 Post,
+                 :upsert_with_no_filter,
+                 return_records?: true,
+                 return_errors?: true,
+                 select: []
+               )
+
+      assert length(records) == 2
+      assert Enum.all?(records, & &1.id)
+
+      assert [10, 20] == Post |> Ash.read!() |> Enum.map(& &1.price) |> Enum.sort()
+    end
+
+    test "bulk upsert returns updated records when select excludes the identity keys" do
+      Ash.bulk_create!(
+        [
+          %{title: "fredfoo", uniq_if_contains_foo: "1foo", price: 10},
+          %{title: "georgefoo", uniq_if_contains_foo: "2foo", price: 20}
+        ],
+        Post,
+        :create
+      )
+
+      assert %Ash.BulkResult{status: :success, records: records} =
+               Ash.bulk_create(
+                 [
+                   %{title: "fredfoo", uniq_if_contains_foo: "1foo", price: 1000},
+                   %{title: "georgefoo", uniq_if_contains_foo: "2foo", price: 20_000}
+                 ],
+                 Post,
+                 :upsert_with_no_filter,
+                 return_records?: true,
+                 return_errors?: true,
+                 select: [:id]
+               )
+
+      assert length(records) == 2
+      assert Enum.all?(records, & &1.id)
+
+      assert [1000, 20_000] == Post |> Ash.read!() |> Enum.map(& &1.price) |> Enum.sort()
+    end
+
     test "bulk upsert returns skipped records with return_skipped_upsert?" do
       assert [
                {:ok, %{title: "fredfoo", uniq_if_contains_foo: "1foo", price: 10}},

--- a/test/bulk_create_test.exs
+++ b/test/bulk_create_test.exs
@@ -381,6 +381,35 @@ defmodule AshPostgres.BulkCreateTest do
       assert [1000, 20_000] == Post |> Ash.read!() |> Enum.map(& &1.price) |> Enum.sort()
     end
 
+    # The correlation key is built per changeset from the upsert identity's keys. When a
+    # multi-field identity leaves one key unset (a nullable field left `nil`, as with a
+    # natural key like `[barcode, timestamp, order_id, route_id]` where `route_id` is
+    # often nil), that key must still appear in the correlation key - otherwise it has
+    # fewer fields than the returned row's key and no row correlates, silently dropping
+    # every record from the result while still writing them.
+    test "bulk upsert returns records when a multi-field identity leaves a key unset (nil)" do
+      assert %Ash.BulkResult{status: :success, records: records} =
+               Ash.bulk_create(
+                 [
+                   %{title: "one-a", uniq_one: "a", price: 10},
+                   %{title: "one-b", uniq_one: "b", price: 20}
+                 ],
+                 Post,
+                 :create,
+                 upsert?: true,
+                 upsert_identity: :uniq_one_and_two,
+                 upsert_fields: [],
+                 return_records?: true,
+                 return_errors?: true,
+                 select: []
+               )
+
+      assert length(records) == 2
+      assert Enum.all?(records, & &1.id)
+
+      assert [10, 20] == Post |> Ash.read!() |> Enum.map(& &1.price) |> Enum.sort()
+    end
+
     test "bulk upsert returns skipped records with return_skipped_upsert?" do
       assert [
                {:ok, %{title: "fredfoo", uniq_if_contains_foo: "1foo", price: 10}},


### PR DESCRIPTION
## Problem

Since #786, bulk upserts can silently drop records from the returned result while still
writing them to the database — so `after_action` hooks and notifiers never run for the
dropped records. This surfaced on the 2.10.0 → 2.11.0 upgrade (same regression as #808/#809).

`bulk_create/3` correlates each returned row back to its changeset by the upsert identity's
keys. Two things break that correlation:

1. **The identity keys aren't selected.** When the action's `select` excludes them
   (e.g. `upsert_fields []` with `select: []`, as `Ash.Reactor`'s `bulk_create` step passes),
   the returned rows don't contain the identity columns, so nothing correlates and every
   record is dropped. This is the fix from @marcnnn's #808, with the regression tests from #809.

2. **Unset (nil) identity keys are missing on the changeset side.** For a multi-field identity
   that leaves a key unset — a nullable field left `nil`, common with `nils_distinct?: false`
   natural keys such as `[barcode, timestamp, order_id, route_id]` — the changeset key is built
   with `Map.take(changeset.attributes, keys)`, which drops the unset key. The changeset's
   correlation key then has fewer fields than the returned row's key (whose `Map.take(row, keys)`
   includes the key as `nil`), so it still never matches even after (1).

## Fix

- Add the identity's attribute keys to the upsert `RETURNING` list so returned rows always
  carry them. `Ash.Actions.Helpers.select/2` masks the extra fields back out of the records,
  so this doesn't widen what callers observe. Identity keys that aren't attributes (e.g. an
  identity over a calculation) have no column and are left out.
- Build the per-changeset correlation key over the full identity key set, defaulting unset
  keys to `nil`, so both sides have the same shape.

## Tests

- `bulk upsert returns inserted records when select excludes the identity keys` (from #809)
- `bulk upsert returns updated records when select excludes the identity keys` (from #809)
- `bulk upsert returns records when a multi-field identity leaves a key unset (nil)` (new;
  covers facet 2)

The fix in (1) and the first two tests are originally by @marcnnn (#808, #809); this PR carries
them and adds the multi-field / nil-identity correlation fix and test on top.

## Note for reviewers

On PostgreSQL 17 (MERGE path) the pre-existing test `returns a skipped upsert whose identity
contains nil` (added by #794) fails with a unique-constraint error — that's a separate
nil-identity issue in the `return_skipped_upsert?` path, unrelated to and not addressed by
this PR.

## Disclosure

Drafted with AI assistance, but every change was reviewed and validated: the failure is
reproduced by a failing test first, the fix is verified against those tests, and the whole
change was exercised end-to-end against a real 8k-test downstream suite on PostgreSQL 17.

---

- [x] Bug fixes include regression tests
