### PR TITLE
Feat/match tenant reference

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -29,6 +29,7 @@ spark_locals_without_parens = [
   index: 2,
   index?: 1,
   index_where: 1,
+  match_tenant?: 1,
   match_type: 1,
   match_with: 1,
   message: 1,

--- a/documentation/dsls/DSL-AshPostgres.DataLayer.md
+++ b/documentation/dsls/DSL-AshPostgres.DataLayer.md
@@ -103,7 +103,7 @@ index ["column", "column2"], unique: true, where: "thing = TRUE"
 
 | Name | Type | Default | Docs |
 |------|------|---------|------|
-| [`fields`](#postgres-custom_indexes-index-fields){: #postgres-custom_indexes-index-fields } | `atom \| String.t \| {:asc \| :desc, atom \| String.t} \| list(atom \| String.t \| {:asc \| :desc, atom \| String.t})` |  | The fields to include in the index.  Each entry can be an atom, string, or a tuple with an order using :desc or :asc and a field. |
+| [`fields`](#postgres-custom_indexes-index-fields){: #postgres-custom_indexes-index-fields } | `atom \| String.t \| {:asc \| :desc, atom \| String.t} \| list(atom \| String.t \| {:asc \| :desc, atom \| String.t})` |  | The fields to include in the index. Each entry can be an atom, string, or a tuple with an order using :desc or :asc and a field. |
 ### Options
 
 | Name | Type | Default | Docs |

--- a/documentation/dsls/DSL-AshPostgres.DataLayer.md
+++ b/documentation/dsls/DSL-AshPostgres.DataLayer.md
@@ -103,7 +103,7 @@ index ["column", "column2"], unique: true, where: "thing = TRUE"
 
 | Name | Type | Default | Docs |
 |------|------|---------|------|
-| [`fields`](#postgres-custom_indexes-index-fields){: #postgres-custom_indexes-index-fields } | `atom \| String.t \| {:asc \| :desc, atom \| String.t} \| list(atom \| String.t \| {:asc \| :desc, atom \| String.t})` |  | The fields to include in the index. Each entry can be an atom, string, or a tuple with an order using :desc or :asc and a field. |
+| [`fields`](#postgres-custom_indexes-index-fields){: #postgres-custom_indexes-index-fields } | `atom \| String.t \| {:asc \| :desc, atom \| String.t} \| list(atom \| String.t \| {:asc \| :desc, atom \| String.t})` |  | The fields to include in the index.  Each entry can be an atom, string, or a tuple with an order using :desc or :asc and a field. |
 ### Options
 
 | Name | Type | Default | Docs |
@@ -318,6 +318,7 @@ reference :post, on_delete: :delete, on_update: :update, name: "comments_to_post
 | [`name`](#postgres-references-reference-name){: #postgres-references-reference-name } | `String.t` |  | The name of the foreign key to generate in the database. Defaults to <table>_<source_attribute>_fkey |
 | [`match_with`](#postgres-references-reference-match_with){: #postgres-references-reference-match_with } | `keyword` |  | Defines additional keys to the foreign key in order to build a composite foreign key. The key should be the name of the source attribute (in the current resource), the value the name of the destination attribute. |
 | [`match_type`](#postgres-references-reference-match_type){: #postgres-references-reference-match_type } | `:simple \| :partial \| :full` |  | select if the match is `:simple`, `:partial`, or `:full` |
+| [`match_tenant?`](#postgres-references-reference-match_tenant?){: #postgres-references-reference-match_tenant? } | `boolean` | `false` | If true, include the multitenancy attribute in the foreign key so tenants must match. |
 | [`index?`](#postgres-references-reference-index?){: #postgres-references-reference-index? } | `boolean` | `false` | Whether to create or not a corresponding index |
 | [`index_where`](#postgres-references-reference-index_where){: #postgres-references-reference-index_where } | `:not_nil \| String.t` |  | A condition to use for the corresponding partial index. Use `:not_nil` to exclude rows where the reference is nil. |
 

--- a/lib/migration_generator/migration_generator.ex
+++ b/lib/migration_generator/migration_generator.ex
@@ -1169,6 +1169,7 @@ defmodule AshPostgres.MigrationGenerator do
           on_update: merge_uniq!(references, table, :on_update, name),
           match_with: merge_uniq!(references, table, :match_with, name) |> to_map(),
           match_type: merge_uniq!(references, table, :match_type, name),
+          match_tenant?: merge_uniq!(references, table, :match_tenant?, name),
           name: merge_uniq!(references, table, :name, name),
           table: merge_uniq!(references, table, :table, name),
           schema: merge_uniq!(references, table, :schema, name)
@@ -3915,6 +3916,7 @@ defmodule AshPostgres.MigrationGenerator do
             on_update: configured_reference.on_update,
             match_with: configured_reference.match_with,
             match_type: configured_reference.match_type,
+            match_tenant?: configured_reference.match_tenant?,
             name: configured_reference.name,
             primary_key?: destination_attribute.primary_key?,
             schema:
@@ -3946,6 +3948,7 @@ defmodule AshPostgres.MigrationGenerator do
         on_update: nil,
         match_with: nil,
         match_type: nil,
+        match_tenant?: false,
         deferrable: false,
         index?: false,
         index_where: nil,
@@ -4370,6 +4373,7 @@ defmodule AshPostgres.MigrationGenerator do
         |> Map.put_new(:index_where, nil)
         |> Map.put_new(:match_with, nil)
         |> Map.put_new(:match_type, nil)
+        |> Map.put_new(:match_tenant?, false)
         |> Map.update!(
           :match_with,
           &(&1 && Enum.into(&1, %{}, fn {k, v} -> {maybe_to_atom(k), maybe_to_atom(v)} end))

--- a/lib/migration_generator/operation.ex
+++ b/lib/migration_generator/operation.ex
@@ -87,23 +87,32 @@ defmodule AshPostgres.MigrationGenerator.Operation do
 
     def with_match(
           %{
-            primary_key?: false,
             destination_attribute: reference_attribute,
             multitenancy: %{strategy: :attribute, attribute: destination_attribute}
           } = reference,
           source_attribute
         )
         when not is_nil(source_attribute) and reference_attribute != destination_attribute do
-      with_targets =
-        [{as_atom(source_attribute), as_atom(destination_attribute)}]
-        |> Enum.into(reference.match_with || %{})
-        |> with_targets()
+      # Non-primary-key destinations always include the tenant column.
+      # Primary-key destinations only do so when match_tenant?: true (opt-in).
+      if !Map.get(reference, :primary_key?, false) or Map.get(reference, :match_tenant?) do
+        with_targets =
+          [{as_atom(source_attribute), as_atom(destination_attribute)}]
+          |> Enum.into(reference.match_with || %{})
+          |> with_targets()
 
-      # We can only have match: :full here, this gets validated by a Transformer
-      join([with_targets, "match: :full"])
+        # We can only have match: :full here, this gets validated by a Transformer
+        join([with_targets, "match: :full"])
+      else
+        explicit_with_match(reference)
+      end
     end
 
     def with_match(reference, _) do
+      explicit_with_match(reference)
+    end
+
+    defp explicit_with_match(reference) do
       with_targets = with_targets(reference.match_with)
       match_type = match_type(reference.match_type)
 

--- a/lib/reference.ex
+++ b/lib/reference.ex
@@ -11,6 +11,7 @@ defmodule AshPostgres.Reference do
     :name,
     :match_with,
     :match_type,
+    :match_tenant?,
     :deferrable,
     :index?,
     :index_where,
@@ -67,6 +68,12 @@ defmodule AshPostgres.Reference do
       match_type: [
         type: {:one_of, [:simple, :partial, :full]},
         doc: "select if the match is `:simple`, `:partial`, or `:full`"
+      ],
+      match_tenant?: [
+        type: :boolean,
+        default: false,
+        doc:
+          "If true, include the multitenancy attribute in the foreign key so tenants must match."
       ],
       index?: [
         type: :boolean,

--- a/test/migration_generator_test.exs
+++ b/test/migration_generator_test.exs
@@ -4170,6 +4170,87 @@ defmodule AshPostgres.MigrationGeneratorTest do
                ~S[references(:users, column: :id, name: "user_things2_user_id_fkey", type: :uuid, prefix: "public")]
     end
 
+    test "match_tenant? adds tenant matching on primary key references", %{
+      snapshot_path: snapshot_path,
+      migration_path: migration_path
+    } do
+      defresource Org, "orgs" do
+        attributes do
+          uuid_primary_key(:id, writable?: true)
+          attribute(:name, :string, public?: true)
+        end
+
+        multitenancy do
+          strategy(:attribute)
+          attribute(:id)
+        end
+      end
+
+      defresource User, "users" do
+        attributes do
+          uuid_primary_key(:id, writable?: true)
+          attribute(:name, :string, public?: true)
+          attribute(:org_id, :uuid, public?: true)
+        end
+
+        multitenancy do
+          strategy(:attribute)
+          attribute(:org_id)
+        end
+
+        relationships do
+          belongs_to(:org, Org) do
+            public?(true)
+          end
+        end
+      end
+
+      defresource UserThing, "user_things" do
+        attributes do
+          uuid_primary_key(:id, writable?: true)
+          attribute(:name, :string, public?: true)
+        end
+
+        multitenancy do
+          strategy(:attribute)
+          attribute(:org_id)
+        end
+
+        relationships do
+          belongs_to(:org, Org) do
+            public?(true)
+          end
+
+          belongs_to(:user, User) do
+            public?(true)
+          end
+        end
+
+        postgres do
+          references do
+            reference(:user, match_tenant?: true)
+          end
+        end
+      end
+
+      defdomain([Org, User, UserThing])
+
+      AshPostgres.MigrationGenerator.generate(Domain,
+        snapshot_path: snapshot_path,
+        migration_path: migration_path,
+        quiet: true,
+        format: false,
+        auto_name: true
+      )
+
+      assert [file] =
+               Path.wildcard("#{migration_path}/**/*_migrate_resources*.exs")
+               |> Enum.reject(&String.contains?(&1, "extensions"))
+
+      assert File.read!(file) =~
+               ~S{references(:users, column: :id, with: [org_id: :org_id], match: :full, name: "user_things_user_id_fkey", type: :uuid, prefix: "public")}
+    end
+
     test "references on_delete: {:nilify, columns} works with multitenant resources", %{
       snapshot_path: snapshot_path,
       migration_path: migration_path


### PR DESCRIPTION
# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [X] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [X] Bug fixes include regression tests
- [ ] Chores
- [X] Documentation changes
- [X] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

## Summary
- Added optional `match_tenant?` on `postgres.references.reference` (default `false`) so attribute-multitenant foreign keys can require matching tenants.
- When enabled, the migration generator includes `with: [tenant: tenant], match: :full` on primary-key references, which blocks cross-tenant relationships at the database.
- Non-PK attribute-tenant references still get tenant matching automatically (existing behavior).
- Addresses https://github.com/ash-project/ash_postgres/issues/192
## Why
Ash used to always add the tenant column to composite FKs. That broke Postgres when the destination was a primary key (#144), because `(id, tenant)` needs a unique index covering those columns. The earlier fix skipped the tenant column for PK references, which unblocked migrations but allowed cross-tenant rows to be inserted.
## Changes
- `lib/reference.ex` — new `match_tenant?` option
- `lib/migration_generator/operation.ex` — include tenant matching on PK refs when the option is on
- `lib/migration_generator/migration_generator.ex` — pass the option through snapshots
- `.formatter.exs` — register `match_tenant?` for Spark formatter
- `documentation/dsls/DSL-AshPostgres.DataLayer.md` — document the option
- `test/migration_generator_test.exs` — test that `match_tenant?: true` generates `with: [org_id: :org_id], match: :full`
## Usage
```elixir
postgres do
  references do
    reference :user, match_tenant?: true
  end
end
```
## Notes
Enabling this on a PK reference may still require a unique index covering `(tenant, id)` on the destination (same Postgres constraint as #144). Happy to follow up if maintainers want that generated automatically.