### PR TITLE
chore: let the booking's guest range be empty

### DIFF
--- a/test/support/resources/booking.ex
+++ b/test/support/resources/booking.ex
@@ -32,7 +32,7 @@ defmodule AshPostgres.Test.Booking do
 
     attribute(:guests, :range) do
       public?(true)
-      constraints(inner_type: :integer)
+      constraints(inner_type: :integer, allow_empty?: true)
     end
   end
 end


### PR DESCRIPTION
# Contributor checklist

- [X] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [X] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

Closes #819

In fixture `allow_empty?: true`

Needs an unreleased ash: `Ash.Type.Range` and its `allow_empty?` constraint are not in
v3.31.3, and CI here takes ash from hex, so this will be red until the next release.

The fixture already depends on the unreleased type — `attribute(:guests, :range)` does not
compile against v3.31.3 either — so this only extends that dependency to the constraint.