### PR TITLE
fix: do not KeyError when Postgres omits DETAIL on a constraint violation

### DIFF
--- a/lib/data_layer.ex
+++ b/lib/data_layer.ex
@@ -3500,7 +3500,7 @@ defmodule AshPostgres.DataLayer do
               private_vars: [
                 constraint: constraint,
                 constraint_type: type,
-                detail: error.postgres.detail
+                detail: error.postgres[:detail]
               ]
             )
           end)


### PR DESCRIPTION
When row-level security applies to the current user, PostgreSQL suppresses the `DETAIL` field of a unique/exclusion constraint violation — `BuildIndexValueDescription` declines to describe an index value the user may not be permitted to see. The Postgrex error map then has **no `:detail` key at all**.

`constraints_to_errors/5` reads it with a bare map access:

```elixir
detail: error.postgres.detail
```

so on any RLS-covered table a constraint violation raises `KeyError` inside error translation, and the caller gets `Ash.Error.Unknown` instead of the `InvalidAttribute` it expects. In practice that turns every "already taken" form error into "unknown error" for applications that use RLS as a tenancy floor.

Reproduced on PostgreSQL 16:

```
no RLS      -> detail present: "Key (id)=(1) already exists."
RLS forced  -> the :detail key is absent from the Postgrex error map
```

`detail` is only passed through to `private_vars`, so reading it optionally loses nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RnyvEB8zkbsLm7eSX6D8PX