### PR TITLE
chore: add tests for the array length rendering fixed by ash_sql

### DIFF
--- a/test/array_length_expr_test.exs
+++ b/test/array_length_expr_test.exs
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: 2019 ash_postgres contributors <https://github.com/ash-project/ash_postgres/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshPostgres.ArrayLengthExprTest do
+  @moduledoc false
+  use AshPostgres.RepoCase, async: false
+
+  alias AshPostgres.Test.Post
+
+  require Ash.Query
+  import Ash.Expr
+
+  defp length_of(list) do
+    post =
+      Post
+      |> Ash.Changeset.for_create(:create, %{title: "a", list_containing_nils: list})
+      |> Ash.create!()
+
+    Post
+    |> Ash.Query.filter(id == ^post.id)
+    |> Ash.Query.calculate(:len, :integer, expr(length(list_containing_nils)))
+    |> Ash.read_one!()
+    |> Map.get(:calculations)
+    |> Map.get(:len)
+  end
+
+  test "an empty list has length zero" do
+    assert length_of([]) == 0
+  end
+
+  test "a populated list has its length" do
+    assert length_of(["a", "b", "c"]) == 3
+  end
+
+  test "a nil list has no length" do
+    assert length_of(nil) == nil
+  end
+
+  test "filtering on the length of an empty list matches" do
+    post =
+      Post
+      |> Ash.Changeset.for_create(:create, %{title: "a", list_containing_nils: []})
+      |> Ash.create!()
+
+    assert [found] =
+             Post
+             |> Ash.Query.filter(length(list_containing_nils) == 0)
+             |> Ash.read!()
+
+    assert found.id == post.id
+  end
+end


### PR DESCRIPTION
# Contributor checklist

- [X] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [X] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

Tests https://github.com/ash-project/ash_sql/pull/255, which must release for this to go green.

Closes #834 with https://github.com/ash-project/ash_sql/pull/255