### PR TITLE
fix: run tenant migrations from mix ash.setup

### DIFF
--- a/lib/data_layer.ex
+++ b/lib/data_layer.ex
@@ -639,13 +639,13 @@ defmodule AshPostgres.DataLayer do
 
     []
     |> AshPostgres.Mix.Helpers.repos!(args)
-    |> Enum.all?(&(not has_tenant_migrations?(&1)))
+    |> Enum.any?(&has_tenant_migrations?(&1))
     |> case do
-      true ->
+      false ->
         :ok
 
       _ ->
-        Mix.Task.run("ash_postgres.migrate", ["--tenant" | args])
+        Mix.Task.rerun("ash_postgres.migrate", ["--tenants" | args])
     end
   end
 
@@ -660,6 +660,7 @@ defmodule AshPostgres.DataLayer do
     |> Path.join("**/*.exs")
     |> Path.wildcard()
     |> Enum.empty?()
+    |> Kernel.not()
   end
 
   import Ecto.Query, only: [from: 2, subquery: 1]

--- a/mix.exs
+++ b/mix.exs
@@ -262,7 +262,12 @@ defmodule AshPostgres.MixProject do
       "test.migrate": "ash_postgres.migrate",
       "test.rollback": "ash_postgres.rollback",
       "test.create": "ash_postgres.create",
-      "test.reset": ["test.drop", "test.create", "test.migrate", "ash_postgres.migrate --tenants"],
+      "test.reset": [
+        "test.drop",
+        "test.create",
+        "test.migrate",
+        fn args -> Mix.Task.rerun("ash_postgres.migrate", ["--tenants" | args]) end
+      ],
       "test.drop": "ash_postgres.drop"
     ]
   end

--- a/test/data_layer_setup_test.exs
+++ b/test/data_layer_setup_test.exs
@@ -1,0 +1,64 @@
+# SPDX-FileCopyrightText: 2019 ash_postgres contributors <https://github.com/ash-project/ash_postgres/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Mix.Tasks.AshPostgres.SetupProbe do
+  @moduledoc false
+  use Mix.Task
+
+  @impl true
+  def run(args) do
+    send(:ash_postgres_setup_probe, {:ash_postgres_setup_probe, args})
+    :ok
+  end
+end
+
+defmodule AshPostgres.DataLayerSetupTest do
+  @moduledoc false
+  use ExUnit.Case, async: false
+
+  describe "has_tenant_migrations?/1" do
+    test "TestRepo has tenant migration files, so setup takes the tenant pass" do
+      files =
+        []
+        |> AshPostgres.Mix.Helpers.tenant_migrations_path(AshPostgres.TestRepo)
+        |> Path.join("**/*.exs")
+        |> Path.wildcard()
+
+      refute Enum.empty?(files)
+    end
+  end
+
+  describe "ash_postgres.migrate switches" do
+    test "rejects --tenant (singular), which is what setup used to pass" do
+      assert_raise Mix.Error, fn ->
+        Mix.Task.rerun("ash_postgres.migrate", ["--tenant"])
+      end
+    end
+  end
+
+  describe "Mix.Task.run/2 vs Mix.Task.rerun/2" do
+    setup do
+      Process.register(self(), :ash_postgres_setup_probe)
+      Mix.Task.reenable("ash_postgres.setup_probe")
+
+      on_exit(fn ->
+        if Process.whereis(:ash_postgres_setup_probe) == self() do
+          Process.unregister(:ash_postgres_setup_probe)
+        end
+      end)
+
+      :ok
+    end
+
+    test "a second Mix.Task.run of the same task is a no-op; Mix.Task.rerun is not" do
+      Mix.Task.run("ash_postgres.setup_probe", ["first"])
+      Mix.Task.run("ash_postgres.setup_probe", ["second"])
+      Mix.Task.rerun("ash_postgres.setup_probe", ["third"])
+
+      assert_received {:ash_postgres_setup_probe, ["first"]}
+      refute_received {:ash_postgres_setup_probe, ["second"]}
+      assert_received {:ash_postgres_setup_probe, ["third"]}
+    end
+  end
+end


### PR DESCRIPTION
Fixes #807.


# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

`mix ash.setup` was supposed to run tenant migrations after public ones, but it never did.

Three bugs:
- `has_tenant_migrations?/1` returned true when there were *no* tenant files
- the second `ash_postgres.migrate` call was skipped because Mix won't run the same task twice (`run` vs `rerun`)
- it passed `--tenant` instead of `--tenants`

This inverts the check, uses `Mix.Task.rerun/2` with `--tenants`, does the same for the `test.reset` alias, and adds regression tests.