### PR TITLE
chore: add tests for the string_position return type fixed by ash

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -135,7 +135,8 @@
         ## Warnings
         #
         {Credo.Check.Warning.BoolOperationOnSameValues, []},
-        {Credo.Check.Warning.ExpensiveEmptyEnumCheck, []},
+        {Credo.Check.Warning.ExpensiveEmptyEnumCheck,
+         [files: %{excluded: ["test/array_length_expr_test.exs"]}]},
         {Credo.Check.Warning.IExPry, []},
         {Credo.Check.Warning.IoInspect, []},
         {Credo.Check.Warning.LazyLogging, []},

--- a/test/string_position_expr_test.exs
+++ b/test/string_position_expr_test.exs
@@ -11,6 +11,15 @@ defmodule AshPostgres.StringPositionExprTest do
   require Ash.Query
   import Ash.Expr
 
+  defp matching(title, filter) do
+    post = Post |> Ash.Changeset.for_create(:create, %{title: title}) |> Ash.create!()
+
+    Post
+    |> Ash.Query.filter(id == ^post.id)
+    |> Ash.Query.do_filter(filter)
+    |> Ash.read!()
+  end
+
   defp position(title, substring) do
     post = Post |> Ash.Changeset.for_create(:create, %{title: title}) |> Ash.create!()
 
@@ -50,5 +59,17 @@ defmodule AshPostgres.StringPositionExprTest do
            |> Ash.read_one!()
            |> Map.get(:calculations)
            |> Map.get(:position) == 2
+  end
+
+  test "a double digit position is greater than a single digit one" do
+    assert [_] = matching("aaaaaaaaaaz", expr(string_position(title, "z") > 9))
+  end
+
+  test "a double digit position is not less than a single digit one" do
+    assert [] = matching("aaaaaaaaaaz", expr(string_position(title, "z") < 9))
+  end
+
+  test "a single digit position is less than a double digit one" do
+    assert [_] = matching("aaz", expr(string_position(title, "z") < 10))
   end
 end


### PR DESCRIPTION
# Contributor checklist

- [X] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [X] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

Tests ash-project/ash#2892, which must release for this to go green.

Also fixes `mix credo --strict`, which has failed on `main` since #835.