### PR TITLE
fix: order temporal migration operations under the toposort

### DIFF
--- a/lib/migration_generator/operation_deps.ex
+++ b/lib/migration_generator/operation_deps.ex
@@ -525,6 +525,17 @@ defmodule AshPostgres.MigrationGenerator.OperationDeps do
         [{:table_structure_ready, key(own_table, schema)}] ++
           Enum.map(after_tables, &{:table_structure_ready, key(&1, schema)})
 
+      %Operation.AddPrimaryKey{table: table, schema: schema} ->
+        # Every key column must exist first; on a temporal resource that includes the period.
+        [{:table_ready, key(table, schema)}, {:table_columns_settled, key(table, schema)}]
+
+      %Operation.AddTemporalForeignKey{} = op ->
+        # References the destination's temporal primary key, so both tables must be complete.
+        [
+          {:table_structure_ready, key(op.table, op.schema)},
+          {:table_structure_ready, key(op.destination_table, op.destination_schema)}
+        ]
+
       _ ->
         []
     end


### PR DESCRIPTION
# Contributor checklist

- [X] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [X] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

Stacked on #838. 

Problem: AddPrimaryKey and AddTemporalForeignKey declared no dependencies, so the toposort that replaced pairwise after?/2 ordering in #798 generated migration ALTER TABLE tier ADD PRIMARY KEY before CREATE TABLE tier.

Fix: declare each operation's actual prerequisites as requires facts, so the generator can't emit a forward reference.

Migration regeneration is subject of next PR in the stack.

@zachdaniel green locally, also credo and format ok. Second of ash_postgres stack likely 4 PR's, stacks on #838 
