### PR TITLE
chore: regenerate the temporal migrations and snapshots

### DIFF
--- a/lib/migration_generator/operation_deps.ex
+++ b/lib/migration_generator/operation_deps.ex
@@ -525,6 +525,17 @@ defmodule AshPostgres.MigrationGenerator.OperationDeps do
         [{:table_structure_ready, key(own_table, schema)}] ++
           Enum.map(after_tables, &{:table_structure_ready, key(&1, schema)})
 
+      %Operation.AddPrimaryKey{table: table, schema: schema} ->
+        # Every key column must exist first; on a temporal resource that includes the period.
+        [{:table_ready, key(table, schema)}, {:table_columns_settled, key(table, schema)}]
+
+      %Operation.AddTemporalForeignKey{} = op ->
+        # References the destination's temporal primary key, so both tables must be complete.
+        [
+          {:table_structure_ready, key(op.table, op.schema)},
+          {:table_structure_ready, key(op.destination_table, op.destination_schema)}
+        ]
+
       _ ->
         []
     end

--- a/test_priv/resource_snapshots/test_repo/event/20260824043711.json
+++ b/test_priv/resource_snapshots/test_repo/event/20260824043711.json
@@ -1,0 +1,57 @@
+{
+  "attributes": [
+    {
+      "allow_nil?": false,
+      "default": "nil",
+      "generated?": false,
+      "precision": null,
+      "primary_key?": true,
+      "references": null,
+      "scale": null,
+      "size": null,
+      "source": "id",
+      "type": "bigint"
+    },
+    {
+      "allow_nil?": true,
+      "default": "nil",
+      "generated?": false,
+      "precision": null,
+      "primary_key?": false,
+      "references": null,
+      "scale": null,
+      "size": null,
+      "source": "name",
+      "type": "text"
+    },
+    {
+      "allow_nil?": true,
+      "default": "nil",
+      "generated?": false,
+      "precision": null,
+      "primary_key?": false,
+      "references": null,
+      "scale": null,
+      "size": null,
+      "source": "created",
+      "type": "utc_datetime_usec"
+    }
+  ],
+  "base_filter": null,
+  "check_constraints": [],
+  "create_table_options": null,
+  "custom_indexes": [],
+  "custom_statements": [],
+  "has_create_action": false,
+  "hash": "E7967071B2D8054BFE5787408ED2DE625F213CCD28C592078468D413C2BB5B8C",
+  "identities": [],
+  "multitenancy": {
+    "attribute": null,
+    "global": null,
+    "strategy": null
+  },
+  "repo": "Elixir.AshPostgres.TestRepo",
+  "schema": null,
+  "table": "event",
+  "temporal": null
+}

--- a/test_priv/resource_snapshots/test_repo/event/20260824043711.json.license
+++ b/test_priv/resource_snapshots/test_repo/event/20260824043711.json.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2019 ash_postgres contributors <https://github.com/ash-project/ash_postgres/graphs/contributors>
+
+SPDX-License-Identifier: MIT

--- a/test_priv/resource_snapshots/test_repo/subscription/20260824043713.json
+++ b/test_priv/resource_snapshots/test_repo/subscription/20260824043713.json
@@ -1,0 +1,121 @@
+{
+  "attributes": [
+    {
+      "allow_nil?": false,
+      "default": "nil",
+      "generated?": false,
+      "precision": null,
+      "primary_key?": true,
+      "references": null,
+      "scale": null,
+      "size": null,
+      "source": "id",
+      "type": "bigint"
+    },
+    {
+      "allow_nil?": true,
+      "default": "nil",
+      "generated?": false,
+      "precision": null,
+      "primary_key?": false,
+      "references": null,
+      "scale": null,
+      "size": null,
+      "source": "tier",
+      "type": "text"
+    },
+    {
+      "allow_nil?": true,
+      "default": "nil",
+      "generated?": false,
+      "precision": null,
+      "primary_key?": false,
+      "references": {
+        "deferrable": false,
+        "destination_attribute": "id",
+        "destination_attribute_default": null,
+        "destination_attribute_generated": null,
+        "index?": false,
+        "index_where": null,
+        "match_tenant?": false,
+        "match_type": null,
+        "match_with": null,
+        "multitenancy": {
+          "attribute": null,
+          "global": null,
+          "strategy": null
+        },
+        "name": "subscription_tier_id_fkey",
+        "on_delete": null,
+        "on_update": null,
+        "primary_key?": true,
+        "schema": "public",
+        "table": "tier",
+        "temporal_period": [
+          "valid_at",
+          "valid_at"
+        ]
+      },
+      "scale": null,
+      "size": null,
+      "source": "tier_id",
+      "type": "bigint"
+    },
+    {
+      "allow_nil?": true,
+      "default": "0",
+      "generated?": false,
+      "precision": null,
+      "primary_key?": false,
+      "references": null,
+      "scale": null,
+      "size": null,
+      "source": "seats",
+      "type": "bigint"
+    },
+    {
+      "allow_nil?": true,
+      "default": "nil",
+      "generated?": false,
+      "precision": null,
+      "primary_key?": false,
+      "references": null,
+      "scale": null,
+      "size": null,
+      "source": "activated_at",
+      "type": "utc_datetime_usec"
+    },
+    {
+      "allow_nil?": false,
+      "default": "nil",
+      "generated?": true,
+      "precision": null,
+      "primary_key?": false,
+      "references": null,
+      "scale": null,
+      "size": null,
+      "source": "valid_at",
+      "type": "tstzrange"
+    }
+  ],
+  "base_filter": null,
+  "check_constraints": [],
+  "create_table_options": null,
+  "custom_indexes": [],
+  "custom_statements": [],
+  "has_create_action": true,
+  "hash": "BB2835F7273E3D9FC169BC7715F0E8363991B560D5C23FCFB3CF9D7A41B2FAE5",
+  "identities": [],
+  "multitenancy": {
+    "attribute": null,
+    "global": null,
+    "strategy": null
+  },
+  "repo": "Elixir.AshPostgres.TestRepo",
+  "schema": null,
+  "table": "subscription",
+  "temporal": {
+    "attribute": "valid_at",
+    "strategy": "context"
+  }
+}

--- a/test_priv/resource_snapshots/test_repo/subscription/20260824043713.json.license
+++ b/test_priv/resource_snapshots/test_repo/subscription/20260824043713.json.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2019 ash_postgres contributors <https://github.com/ash-project/ash_postgres/graphs/contributors>
+
+SPDX-License-Identifier: MIT

--- a/test_priv/resource_snapshots/test_repo/tier/20260824043712.json
+++ b/test_priv/resource_snapshots/test_repo/tier/20260824043712.json
@@ -1,0 +1,60 @@
+{
+  "attributes": [
+    {
+      "allow_nil?": false,
+      "default": "nil",
+      "generated?": false,
+      "precision": null,
+      "primary_key?": true,
+      "references": null,
+      "scale": null,
+      "size": null,
+      "source": "id",
+      "type": "bigint"
+    },
+    {
+      "allow_nil?": true,
+      "default": "nil",
+      "generated?": false,
+      "precision": null,
+      "primary_key?": false,
+      "references": null,
+      "scale": null,
+      "size": null,
+      "source": "name",
+      "type": "text"
+    },
+    {
+      "allow_nil?": false,
+      "default": "nil",
+      "generated?": true,
+      "precision": null,
+      "primary_key?": false,
+      "references": null,
+      "scale": null,
+      "size": null,
+      "source": "valid_at",
+      "type": "tstzrange"
+    }
+  ],
+  "base_filter": null,
+  "check_constraints": [],
+  "create_table_options": null,
+  "custom_indexes": [],
+  "custom_statements": [],
+  "has_create_action": true,
+  "hash": "94A1C6C459EB720CC502D358935D76F39DD1D36D15A5868B67BCA4A16860BA1E",
+  "identities": [],
+  "multitenancy": {
+    "attribute": null,
+    "global": null,
+    "strategy": null
+  },
+  "repo": "Elixir.AshPostgres.TestRepo",
+  "schema": null,
+  "table": "tier",
+  "temporal": {
+    "attribute": "valid_at",
+    "strategy": "context"
+  }
+}

--- a/test_priv/resource_snapshots/test_repo/tier/20260824043712.json.license
+++ b/test_priv/resource_snapshots/test_repo/tier/20260824043712.json.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2019 ash_postgres contributors <https://github.com/ash-project/ash_postgres/graphs/contributors>
+
+SPDX-License-Identifier: MIT

--- a/test_priv/test_repo/migrations/20260824043709_temporal_extensions.exs
+++ b/test_priv/test_repo/migrations/20260824043709_temporal_extensions.exs
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 
-defmodule AshPostgres.TestRepo.Migrations.TemporalMoreExtensions1 do
+defmodule AshPostgres.TestRepo.Migrations.TemporalExtensions do
   @moduledoc """
   Installs any extensions that are mentioned in the repo's `installed_extensions/0` callback
 

--- a/test_priv/test_repo/migrations/20260824043710_migrate_resources74.exs
+++ b/test_priv/test_repo/migrations/20260824043710_migrate_resources74.exs
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 
-defmodule AshPostgres.TestRepo.Migrations.TemporalMore do
+defmodule AshPostgres.TestRepo.Migrations.MigrateResources74 do
   @moduledoc """
   Updates resources based on their most recent snapshots.
 
@@ -12,25 +12,16 @@ defmodule AshPostgres.TestRepo.Migrations.TemporalMore do
   use Ecto.Migration
 
   def up do
-    create table(:subscription, primary_key: false) do
-      add(:id, :bigint, null: false)
-      add(:tier, :text)
-      add(:tier_id, :bigint)
-      add(:seats, :bigint, default: 0)
-      add(:activated_at, :utc_datetime_usec)
-      add(:valid_at, :tstzrange)
+    create table(:event, primary_key: false) do
+      add(:id, :bigint, null: false, primary_key: true)
+      add(:name, :text)
+      add(:created, :utc_datetime_usec)
     end
 
     create table(:tier, primary_key: false) do
       add(:id, :bigint, null: false)
       add(:name, :text)
-      add(:valid_at, :tstzrange)
-    end
-
-    create table(:event, primary_key: false) do
-      add(:id, :bigint, null: false, primary_key: true)
-      add(:name, :text)
-      add(:created, :utc_datetime_usec)
+      add(:valid_at, :tstzrange, null: false)
     end
 
     if repo().query!("SHOW server_version_num").rows |> hd() |> hd() |> String.to_integer() >=
@@ -38,6 +29,15 @@ defmodule AshPostgres.TestRepo.Migrations.TemporalMore do
       execute("ALTER TABLE \"tier\" ADD PRIMARY KEY (id, valid_at WITHOUT OVERLAPS)")
     else
       execute("ALTER TABLE \"tier\" ADD PRIMARY KEY (id)")
+    end
+
+    create table(:subscription, primary_key: false) do
+      add(:id, :bigint, null: false)
+      add(:tier, :text)
+      add(:tier_id, :bigint)
+      add(:seats, :bigint, default: 0)
+      add(:activated_at, :utc_datetime_usec)
+      add(:valid_at, :tstzrange, null: false)
     end
 
     if repo().query!("SHOW server_version_num").rows |> hd() |> hd() |> String.to_integer() >=
@@ -58,10 +58,10 @@ defmodule AshPostgres.TestRepo.Migrations.TemporalMore do
   def down do
     execute("ALTER TABLE \"subscription\" DROP CONSTRAINT subscription_tier_id_fkey")
 
-    drop(table(:event))
+    drop(table(:subscription))
 
     drop(table(:tier))
 
-    drop(table(:subscription))
+    drop(table(:event))
   end
 end


### PR DESCRIPTION
# Contributor checklist

- [X] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [X] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

Regenerates the temporal migration and snapshot set with the corrected operation ordering, and renames the generated extensions migration to avoid a name collision with an unrelated 2025 migration.

@zachdaniel stacks on #838 and #839, 3rd and last PR of stack. `mix test.check_migrations` passes once this lands, resolving the pending codegen