### PR TITLE
chore: cover the codepoint count of a decomposed string

### DIFF
--- a/test/string_length_test.exs
+++ b/test/string_length_test.exs
@@ -1,0 +1,24 @@
+defmodule AshPostgres.StringLengthTest do
+  use AshPostgres.RepoCase, async: false
+
+  alias Ash.Query.Function.StringLength
+  alias AshPostgres.Test.Post
+
+  require Ash.Query
+  import Ash.Expr
+
+  # Decomposed, so the stored value is 11 codepoints and its NFC form is 7.
+  @decomposed :unicode.characters_to_nfd_binary("ünïcödé")
+
+  test "string_length counts codepoints on the stored value" do
+    Post |> Ash.Changeset.for_create(:create, %{title: @decomposed}) |> Ash.create!()
+
+    expected = StringLength.string_length(@decomposed, :codepoints)
+
+    assert %{length: ^expected} =
+             Post
+             |> Ash.Query.calculate(:length, :integer, expr(string_length(title, :codepoints)))
+             |> Ash.read_one!()
+             |> Map.get(:calculations)
+  end
+end


### PR DESCRIPTION
# Contributor checklist

- [X] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [X] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

# Summary

Closes #845 
will be red until ash_sql releases with ash_sql#261