### PR TITLE
fix: order no_phase operations after the objects they act on

### DIFF
--- a/lib/migration_generator/operation_deps.ex
+++ b/lib/migration_generator/operation_deps.ex
@@ -19,20 +19,12 @@ defmodule AshPostgres.MigrationGenerator.OperationDeps do
   barrier would need it to run last — contradictory. Give each operation
   type the ordering it needs via `requires/1` instead.
 
-  Operations flagged `no_phase: true` are not grouped into the create/alter
-  phases that order the rest (see `group_into_phases/3`); they carry no
-  implicit ordering and float freely unless `requires/1` gives them an edge.
-  Any such operation whose `up` SQL names an object another operation can
-  create in the same batch (a column, a foreign key, a table, an index) has to
-  require that object's creation fact, or it can run before the object exists.
-  Most need no such requirement: they act only on objects that predate the
-  batch (a rename or drop of something an earlier migration made, e.g.
-  `RenameTable`, `RemoveCustomIndex`), render nothing in `up` (the `*Down`
-  helpers, which exist only to shape the reversed `down`), or are held in place
-  by the consumers that require their facts. The two that act on an
-  in-batch-created object are `AlterDeferrability` (the foreign key a new
-  `belongs_to` adds) and `AddPrimaryKey` (a column a new attribute adds); each
-  requires the relevant fact in `requires/1` below.
+  Operations flagged `no_phase: true` float freely (they skip the create/alter
+  phases; see `group_into_phases/3`) unless `requires/1` gives them an edge. One
+  whose `up` SQL names an object another operation creates in the same batch must
+  require that object's fact, or it runs first. Only `AlterDeferrability` and
+  `AddPrimaryKey` do; the rest act on pre-existing objects, render nothing in
+  `up`, or are ordered by their facts' consumers.
 
   Requiring a fact waits on *every* operation that provides it, not just one
   — see `toposort_operations/1`'s `provides_index`. That's what makes
@@ -345,26 +337,15 @@ defmodule AshPostgres.MigrationGenerator.OperationDeps do
         [{:table_ready, key(table, schema)}] ++
           reference_requirements(attribute, table, schema)
 
-      # An `ALTER CONSTRAINT ... DEFERRABLE` runs against a foreign key that a column
-      # operation on this table creates in the same batch (an `add`/`modify` carrying
-      # `references:`, which provides `table_columns_settled`). Without a requirement it
-      # floats to the front and fails with "constraint ... does not exist" whenever the
-      # referenced table forces the FK into a later phase, e.g. a composite `with:` key
-      # to a table created later in the same batch. The `:down` direction drops
-      # deferrability ahead of everything via `early_tier?`, so only `:up` orders here.
+      # `ALTER CONSTRAINT ... DEFERRABLE` runs against a foreign key an `AddAttribute`
+      # in this batch creates (it provides `table_columns_settled`); without this it
+      # floats ahead and fails "constraint does not exist". `:down` drops it early_tier.
       %Operation.AlterDeferrability{table: table, schema: schema, direction: :up} ->
         [{:table_columns_settled, key(table, schema)}]
 
-      # `ALTER TABLE ... ADD PRIMARY KEY (keys)` runs against columns an `AddAttribute`
-      # in the same batch can create: a new attribute folded into a composite primary
-      # key (e.g. list-partitioning that adds a partition-key column and widens the
-      # primary key to include it) emits `AddAttribute` for that column plus this op.
-      # As a `no_phase` op with no requirement it otherwise floats to the front and adds
-      # the primary key before the column exists. Require each key column's existence;
-      # the requirement is vacuous for a key that already exists from an earlier
-      # migration (nothing in this batch provides its `column_ready`). No cycle: this
-      # provides only `table_structure_ready`, and `AddAttribute` requires `table_ready`
-      # and its references' facts, never `table_structure_ready` of its own table.
+      # `ADD PRIMARY KEY (keys)` runs against columns an `AddAttribute` in this batch can
+      # add (a new attribute folded into a composite key), so require each; without this
+      # it floats ahead of the add. Vacuous for pre-existing keys, and no cycle.
       %Operation.AddPrimaryKey{table: table, schema: schema, keys: keys} ->
         Enum.map(keys, &{:column_ready, key(table, schema, &1)})
 

--- a/lib/migration_generator/operation_deps.ex
+++ b/lib/migration_generator/operation_deps.ex
@@ -19,6 +19,21 @@ defmodule AshPostgres.MigrationGenerator.OperationDeps do
   barrier would need it to run last — contradictory. Give each operation
   type the ordering it needs via `requires/1` instead.
 
+  Operations flagged `no_phase: true` are not grouped into the create/alter
+  phases that order the rest (see `group_into_phases/3`); they carry no
+  implicit ordering and float freely unless `requires/1` gives them an edge.
+  Any such operation whose `up` SQL names an object another operation can
+  create in the same batch (a column, a foreign key, a table, an index) has to
+  require that object's creation fact, or it can run before the object exists.
+  Most need no such requirement: they act only on objects that predate the
+  batch (a rename or drop of something an earlier migration made, e.g.
+  `RenameTable`, `RemoveCustomIndex`), render nothing in `up` (the `*Down`
+  helpers, which exist only to shape the reversed `down`), or are held in place
+  by the consumers that require their facts. The two that act on an
+  in-batch-created object are `AlterDeferrability` (the foreign key a new
+  `belongs_to` adds) and `AddPrimaryKey` (a column a new attribute adds); each
+  requires the relevant fact in `requires/1` below.
+
   Requiring a fact waits on *every* operation that provides it, not just one
   — see `toposort_operations/1`'s `provides_index`. That's what makes
   `:table_structure_ready` works as a catch-all: many operation types provide
@@ -329,6 +344,29 @@ defmodule AshPostgres.MigrationGenerator.OperationDeps do
       %Operation.AddAttribute{table: table, schema: schema, attribute: attribute} ->
         [{:table_ready, key(table, schema)}] ++
           reference_requirements(attribute, table, schema)
+
+      # An `ALTER CONSTRAINT ... DEFERRABLE` runs against a foreign key that a column
+      # operation on this table creates in the same batch (an `add`/`modify` carrying
+      # `references:`, which provides `table_columns_settled`). Without a requirement it
+      # floats to the front and fails with "constraint ... does not exist" whenever the
+      # referenced table forces the FK into a later phase, e.g. a composite `with:` key
+      # to a table created later in the same batch. The `:down` direction drops
+      # deferrability ahead of everything via `early_tier?`, so only `:up` orders here.
+      %Operation.AlterDeferrability{table: table, schema: schema, direction: :up} ->
+        [{:table_columns_settled, key(table, schema)}]
+
+      # `ALTER TABLE ... ADD PRIMARY KEY (keys)` runs against columns an `AddAttribute`
+      # in the same batch can create: a new attribute folded into a composite primary
+      # key (e.g. list-partitioning that adds a partition-key column and widens the
+      # primary key to include it) emits `AddAttribute` for that column plus this op.
+      # As a `no_phase` op with no requirement it otherwise floats to the front and adds
+      # the primary key before the column exists. Require each key column's existence;
+      # the requirement is vacuous for a key that already exists from an earlier
+      # migration (nothing in this batch provides its `column_ready`). No cycle: this
+      # provides only `table_structure_ready`, and `AddAttribute` requires `table_ready`
+      # and its references' facts, never `table_structure_ready` of its own table.
+      %Operation.AddPrimaryKey{table: table, schema: schema, keys: keys} ->
+        Enum.map(keys, &{:column_ready, key(table, schema, &1)})
 
       %Operation.AlterAttribute{
         table: table,

--- a/test/migration_generator/operation_deps_test.exs
+++ b/test/migration_generator/operation_deps_test.exs
@@ -809,4 +809,108 @@ defmodule AshPostgres.MigrationGenerator.OperationDepsTest do
       assert fact in OperationDeps.requires(remove_index)
     end
   end
+
+  describe "foreign key deferrability" do
+    test "AlterDeferrability{direction: :up} requires table_columns_settled, satisfied by the AddAttribute that adds the foreign key it alters" do
+      # `ALTER CONSTRAINT ... DEFERRABLE` runs against a foreign key an
+      # `AddAttribute` carrying `references:` creates in the same batch. As a
+      # `no_phase` op it otherwise floats to the front and alters a constraint
+      # that does not exist yet (reproduced when a composite `with:` key pushes
+      # the foreign key into a later phase).
+      alter_def = %Operation.AlterDeferrability{
+        table: "comments",
+        schema: nil,
+        references: %{},
+        direction: :up
+      }
+
+      add_fk_column = %Operation.AddAttribute{
+        table: "comments",
+        schema: nil,
+        attribute: %{
+          source: :post_id,
+          primary_key?: false,
+          references: %{table: "posts", destination_attribute: :id, schema: "public"}
+        }
+      }
+
+      [settled_fact] =
+        OperationDeps.provides(add_fk_column)
+        |> Enum.filter(&match?({:table_columns_settled, _}, &1))
+
+      assert settled_fact == {:table_columns_settled, {"public", "comments"}}
+      assert settled_fact in OperationDeps.requires(alter_def)
+    end
+
+    test "AlterDeferrability{direction: :up} is ordered after the AddAttribute that creates the foreign key" do
+      add_fk_column = %Operation.AddAttribute{
+        table: "comments",
+        schema: nil,
+        attribute: %{
+          source: :post_id,
+          primary_key?: false,
+          references: %{table: "posts", destination_attribute: :id, schema: "public"}
+        }
+      }
+
+      alter_def = %Operation.AlterDeferrability{
+        table: "comments",
+        schema: nil,
+        references: %{},
+        direction: :up
+      }
+
+      # The input lists the deferrability alter first on purpose: only the
+      # dependency edge, not input order, can put the column add ahead of it.
+      operations = MigrationGenerator.toposort_operations([alter_def, add_fk_column])
+
+      add_index = Enum.find_index(operations, &match?(%Operation.AddAttribute{}, &1))
+      def_index = Enum.find_index(operations, &match?(%Operation.AlterDeferrability{}, &1))
+
+      assert add_index < def_index
+    end
+  end
+
+  describe "primary key columns" do
+    test "AddPrimaryKey requires column_ready for each key, satisfied by the AddAttribute that adds a new composite-pkey column" do
+      # Widening a primary key from (id) to (id, cell_id) and adding cell_id in
+      # the same batch (list-partitioning by cell_id) emits `AddAttribute` for
+      # the column plus `AddPrimaryKey` over both columns. `ADD PRIMARY KEY (id,
+      # cell_id)` must run after the column is added, or it references a column
+      # that does not exist yet.
+      add_pk = %Operation.AddPrimaryKey{table: "accounts", schema: nil, keys: [:id, :cell_id]}
+
+      add_cell_id = %Operation.AddAttribute{
+        table: "accounts",
+        schema: nil,
+        attribute: %{source: :cell_id, primary_key?: true}
+      }
+
+      [column_ready_fact] =
+        OperationDeps.provides(add_cell_id) |> Enum.filter(&match?({:column_ready, _}, &1))
+
+      assert column_ready_fact == {:column_ready, {"public", "accounts", :cell_id}}
+      assert column_ready_fact in OperationDeps.requires(add_pk)
+    end
+
+    test "AddPrimaryKey is ordered after the AddAttribute that creates a new composite primary-key column" do
+      add_cell_id = %Operation.AddAttribute{
+        table: "accounts",
+        schema: nil,
+        attribute: %{source: :cell_id, primary_key?: true}
+      }
+
+      add_pk = %Operation.AddPrimaryKey{table: "accounts", schema: nil, keys: [:id, :cell_id]}
+
+      # The input lists the primary key first on purpose: `AddPrimaryKey` is a
+      # `no_phase` op that floats, so only the dependency edge (not input order)
+      # can put the column add ahead of it.
+      operations = MigrationGenerator.toposort_operations([add_pk, add_cell_id])
+
+      add_index = Enum.find_index(operations, &match?(%Operation.AddAttribute{}, &1))
+      pk_index = Enum.find_index(operations, &match?(%Operation.AddPrimaryKey{}, &1))
+
+      assert add_index < pk_index
+    end
+  end
 end

--- a/test/migration_generator/operation_deps_test.exs
+++ b/test/migration_generator/operation_deps_test.exs
@@ -812,11 +812,6 @@ defmodule AshPostgres.MigrationGenerator.OperationDepsTest do
 
   describe "foreign key deferrability" do
     test "AlterDeferrability{direction: :up} requires table_columns_settled, satisfied by the AddAttribute that adds the foreign key it alters" do
-      # `ALTER CONSTRAINT ... DEFERRABLE` runs against a foreign key an
-      # `AddAttribute` carrying `references:` creates in the same batch. As a
-      # `no_phase` op it otherwise floats to the front and alters a constraint
-      # that does not exist yet (reproduced when a composite `with:` key pushes
-      # the foreign key into a later phase).
       alter_def = %Operation.AlterDeferrability{
         table: "comments",
         schema: nil,
@@ -860,8 +855,7 @@ defmodule AshPostgres.MigrationGenerator.OperationDepsTest do
         direction: :up
       }
 
-      # The input lists the deferrability alter first on purpose: only the
-      # dependency edge, not input order, can put the column add ahead of it.
+      # Alter listed first on purpose: only the dependency edge can reorder it.
       operations = MigrationGenerator.toposort_operations([alter_def, add_fk_column])
 
       add_index = Enum.find_index(operations, &match?(%Operation.AddAttribute{}, &1))
@@ -873,11 +867,7 @@ defmodule AshPostgres.MigrationGenerator.OperationDepsTest do
 
   describe "primary key columns" do
     test "AddPrimaryKey requires column_ready for each key, satisfied by the AddAttribute that adds a new composite-pkey column" do
-      # Widening a primary key from (id) to (id, cell_id) and adding cell_id in
-      # the same batch (list-partitioning by cell_id) emits `AddAttribute` for
-      # the column plus `AddPrimaryKey` over both columns. `ADD PRIMARY KEY (id,
-      # cell_id)` must run after the column is added, or it references a column
-      # that does not exist yet.
+      # Widening the primary key to include a newly added column (cell_id).
       add_pk = %Operation.AddPrimaryKey{table: "accounts", schema: nil, keys: [:id, :cell_id]}
 
       add_cell_id = %Operation.AddAttribute{
@@ -902,9 +892,7 @@ defmodule AshPostgres.MigrationGenerator.OperationDepsTest do
 
       add_pk = %Operation.AddPrimaryKey{table: "accounts", schema: nil, keys: [:id, :cell_id]}
 
-      # The input lists the primary key first on purpose: `AddPrimaryKey` is a
-      # `no_phase` op that floats, so only the dependency edge (not input order)
-      # can put the column add ahead of it.
+      # AddPrimaryKey listed first on purpose: only the dependency edge can reorder it.
       operations = MigrationGenerator.toposort_operations([add_pk, add_cell_id])
 
       add_index = Enum.find_index(operations, &match?(%Operation.AddAttribute{}, &1))


### PR DESCRIPTION
## Problem

An operation flagged `no_phase: true` carries no implicit ordering, so without a `requires/1` clause it floats ahead of the phased operations that build a table's structure. Two such operations render SQL against an object another operation creates in the *same batch*, so floating puts them before that object exists:

- **`AlterDeferrability`** (`ALTER CONSTRAINT ... DEFERRABLE`) runs against a foreign key an `AddAttribute` carrying `references:` creates. When a composite `with:` key pushes the foreign key into a later phase, the deferrability alter ran first and failed with `constraint ... does not exist`.
- **`AddPrimaryKey`** (`ADD PRIMARY KEY (keys)`) runs against key columns an `AddAttribute` can add in the same batch. Widening a primary key to include a newly added column (list-partitioning by that column, for instance) generated `ADD PRIMARY KEY (id, cell_id)` before `cell_id` existed.

## Fix

Give each a `requires/1` clause: `AlterDeferrability{direction: :up}` requires `table_columns_settled`; `AddPrimaryKey` requires `column_ready` for each key column. Both requirements are vacuous when the object predates the batch (nothing in the batch provides the fact), and neither adds a cycle: each provides only `table_structure_ready`, which `AddAttribute` never requires.

This builds on the dependency-graph model from #798, and is a distinct case from the composite-primary-key work in #805, which addressed the `streamline` merge and the `DropForeignKey{direction: :down}` phase split rather than `ADD PRIMARY KEY` over a newly added column.

## The class

The module doc now documents the whole class, so future `no_phase` operations are held to it. The rest are already safe: they act on objects that predate the batch (`RenameTable`, `MoveTableSchema`, `RemoveCustomIndex`, and the other renames and drops), render nothing in `up` (the `*Down` helpers), or are ordered by the consumers that require their facts.

## Tests

Reproducing tests for both fixes in `operation_deps_test.exs`, at both the `requires`/`provides` level and the `toposort_operations/1` level. Each fails without its `requires` clause (verified by neutralizing the clause).

- Full test suite passes.
- `mix ash_postgres.generate_migrations --check` is clean for both PG variants, so no checked-in migration reorders.