### PR TITLE
chore: require an ash_sql without the advisories 0.7.0 carries

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -189,7 +189,7 @@ defmodule AshPostgres.MixProject do
     [
       {:ash, ash_version("~> 3.32")},
       {:spark, "~> 2.3 and >= 2.3.4"},
-      {:ash_sql, ash_sql_version("~> 0.7")},
+      {:ash_sql, ash_sql_version("~> 0.7 and >= 0.7.1")},
       {:igniter, "~> 0.6 and >= 0.6.29", optional: true},
       {:ecto_sql, "~> 3.13"},
       {:ecto, "~> 3.13"},

--- a/test/string_length_test.exs
+++ b/test/string_length_test.exs
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2019 ash_postgres contributors <https://github.com/ash-project/ash_postgres/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
 defmodule AshPostgres.StringLengthTest do
   use AshPostgres.RepoCase, async: false
 


### PR DESCRIPTION
# Contributor checklist

- [X] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [X] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

# Summary

`~> 0.7` permits ash_sql 0.7.0, which carries five published advisories and fails ten of this repo's own tests.
